### PR TITLE
(#55) invoices projects

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -101,4 +101,15 @@ class ClientController extends Controller
     {
         //
     }
+
+    /**
+     * Get all the projects for a client
+     *
+     * @param  \App\Models\Client $client
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getProjects(Client $client)
+    {
+        return $client->projects;
+    }
 }

--- a/app/Http/Controllers/Finance/InvoiceController.php
+++ b/app/Http/Controllers/Finance/InvoiceController.php
@@ -48,7 +48,6 @@ class InvoiceController extends Controller
         $validated = $request->validated();
         $path = self::upload($validated['invoice_file']);
         $invoice = Invoice::create([
-            'project_id' => $validated['project_id'],
             'project_invoice_id' => $validated['project_invoice_id'],
             'status' => $validated['status'],
             'sent_on' => DateHelper::formatDateToSave($validated['sent_on']),
@@ -60,6 +59,7 @@ class InvoiceController extends Controller
             'comments' => $validated['comments'],
             'file_path' => $path
         ]);
+        $invoice->projects()->sync($validated['project_ids']);
 
         return redirect('/finance/invoices');
     }
@@ -100,7 +100,6 @@ class InvoiceController extends Controller
     {
         $validated = $request->validated();
         $updated = $invoice->update([
-            'project_id' => $validated['project_id'],
             'project_invoice_id' => $validated['project_invoice_id'],
             'status' => $validated['status'],
             'sent_on' => DateHelper::formatDateToSave($validated['sent_on']),
@@ -111,6 +110,8 @@ class InvoiceController extends Controller
             'currency_paid_amount' => $validated['currency_paid_amount'],
             'comments' => $validated['comments'],
         ]);
+        $invoice->projects()->sync($validated['project_ids']);
+
         return redirect('/finance/invoices/' . $invoice->id . '/edit');
     }
 

--- a/app/Http/Controllers/Finance/InvoiceController.php
+++ b/app/Http/Controllers/Finance/InvoiceController.php
@@ -6,8 +6,8 @@ use App\Helpers\DateHelper;
 use App\Helpers\FileHelper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Finance\InvoiceRequest;
+use App\Models\Client;
 use App\Models\Finance\Invoice;
-use App\Models\Project;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
@@ -33,7 +33,7 @@ class InvoiceController extends Controller
     public function create()
     {
         return view('finance.invoice.create')->with([
-            'projects' => Project::select('id', 'name')->get(),
+            'clients' => Client::select('id', 'name')->get(),
         ]);
     }
 
@@ -83,9 +83,17 @@ class InvoiceController extends Controller
      */
     public function edit(Invoice $invoice)
     {
+        $projects = $invoice->projects;
+        foreach ($projects as $project) {
+            $client = $project->client;
+            $client_projects = $client->projects;
+            break;
+        }
         return view('finance.invoice.edit')->with([
             'invoice' => $invoice,
-            'projects' => Project::select('id', 'name')->get(),
+            'clients' => Client::select('id', 'name')->get(),
+            'invoice_client' => $client,
+            'client_projects' => $client_projects,
         ]);
     }
 

--- a/app/Http/Controllers/Finance/InvoiceController.php
+++ b/app/Http/Controllers/Finance/InvoiceController.php
@@ -83,12 +83,10 @@ class InvoiceController extends Controller
      */
     public function edit(Invoice $invoice)
     {
-        $projects = $invoice->projects;
-        foreach ($projects as $project) {
-            $client = $project->client;
-            $client_projects = $client->projects;
-            break;
-        }
+        $project = $invoice->projects->first();
+        $client = $project->client;
+        $client_projects = $client->projects;
+
         return view('finance.invoice.edit')->with([
             'invoice' => $invoice,
             'clients' => Client::select('id', 'name')->get(),

--- a/app/Http/Requests/Finance/InvoiceRequest.php
+++ b/app/Http/Requests/Finance/InvoiceRequest.php
@@ -24,7 +24,7 @@ class InvoiceRequest extends FormRequest
     public function rules()
     {
         $rules = [
-            'project_id' => 'required|integer',
+            'project_ids' => 'required',
             'project_invoice_id' => 'required',
             'status' => 'required|string',
             'sent_on' => 'required',

--- a/app/Models/Finance/Invoice.php
+++ b/app/Models/Finance/Invoice.php
@@ -9,14 +9,14 @@ class Invoice extends Model
 {
     protected $table = 'finance_invoices';
 
-    protected $fillable = ['project_id', 'project_invoice_id', 'review_value', 'status', 'sent_on', 'sent_amount', 'currency_sent_amount', 'paid_on', 'paid_amount', 'currency_paid_amount', 'comments', 'file_path'];
+    protected $fillable = ['project_invoice_id', 'review_value', 'status', 'sent_on', 'sent_amount', 'currency_sent_amount', 'paid_on', 'paid_amount', 'currency_paid_amount', 'comments', 'file_path'];
 
     /**
-     * Get the project that associated with the invoice.
+     * Get the projects associated with the invoice.
      */
-    public function project()
+    public function projects()
     {
-        return $this->belongsTo(Project::class);
+        return $this->belongsToMany(Project::class, 'project_finance_invoices', 'finance_invoice_id');
     }
 
     /**
@@ -26,7 +26,7 @@ class Invoice extends Model
      */
     public static function getList()
     {
-    	return self::with([ 'project' => function($query) {
+    	return self::with([ 'projects' => function($query) {
 	            $query->select('id', 'name');
 	        }])
             ->orderBy('sent_on', 'desc')

--- a/database/migrations/2018_04_04_160344_create_project_finance_invoices_table.php
+++ b/database/migrations/2018_04_04_160344_create_project_finance_invoices_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateProjectFinanceInvoicesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('project_finance_invoices', function (Blueprint $table) {
+            $table->unsignedInteger('project_id');
+            $table->unsignedInteger('finance_invoice_id');
+        });
+
+        Schema::table('project_finance_invoices', function(Blueprint $table) {
+            $table->foreign('project_id')->references('id')->on('projects');
+            $table->foreign('finance_invoice_id')->references('id')->on('finance_invoices');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('project_finance_invoices', function (Blueprint $table) {
+            $table->dropForeign([
+                'project_id',
+                'finance_invoice_id',
+            ]);
+        });
+    }
+}

--- a/database/migrations/2018_04_04_160509_drop_finance_invoices_project_id_column.php
+++ b/database/migrations/2018_04_04_160509_drop_finance_invoices_project_id_column.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropFinanceInvoicesProjectIdColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('finance_invoices', function (Blueprint $table) {
+            $table->dropForeign([ 'project_id' ]);
+            $table->dropColumn('project_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -33,3 +33,38 @@ $('#page-hr-applicant-edit .applicant-round-form').on('click', '.round-submit', 
 $('.date-field').datepicker({
 	dateFormat: "dd/mm/yy"
 });
+
+$('#form_create_invoice, #form_edit_invoice').on('change', '#client_id', function(){
+	let form = $(this).closest('form');
+	let client_id = $(this).val();
+	if (! client_id) {
+		form.find('#project_ids').html('');
+		return false;
+	}
+	updateClientProjects(form, client_id);
+});
+
+function updateClientProjects(form, client_id) {
+	$.ajax({
+		url : '/clients/' + client_id + '/get-projects',
+		method : 'GET',
+		success : function (res) {
+			form.find('#project_ids').html(getProjectList(res));
+		},
+		error : function (err) {
+			console.log(err);
+		}
+
+	});
+}
+
+function getProjectList(projects) {
+	let html = '';
+	for (var index = 0; index < projects.length; index++) {
+		let project = projects[index];
+		html += '<option value="' + project.id + '">';
+		html += project.name;
+		html += '</option>';
+	}
+	return html;
+}

--- a/resources/views/finance/invoice/create.blade.php
+++ b/resources/views/finance/invoice/create.blade.php
@@ -19,8 +19,7 @@
                 <div class="form-row">
                     <div class="form-group col-md-5">
                         <label for="project_id">Project</label>
-                        <select name="project_id" id="project_id" class="form-control" required="required">
-                            <option value="">Select Project</option>
+                        <select name="project_ids[]" id="project_ids" class="form-control" required="required" multiple="multiple">
                             @foreach ($projects as $project)
                                 <option value="{{ $project->id }}">{{ $project->name }}</option>
                             @endforeach

--- a/resources/views/finance/invoice/create.blade.php
+++ b/resources/views/finance/invoice/create.blade.php
@@ -8,7 +8,7 @@
     <a class="btn btn-info" href="/finance/invoices">See all invoices</a>
     <br><br>
     <div class="card">
-        <form action="/finance/invoices" method="POST" enctype="multipart/form-data">
+        <form action="/finance/invoices" method="POST" enctype="multipart/form-data" id="form_create_invoice">
 
             {{ csrf_field() }}
 
@@ -18,21 +18,27 @@
             <div class="card-body">
                 <div class="form-row">
                     <div class="form-group col-md-5">
-                        <label for="project_id">Project</label>
-                        <select name="project_ids[]" id="project_ids" class="form-control" required="required" multiple="multiple">
-                            @foreach ($projects as $project)
-                                <option value="{{ $project->id }}">{{ $project->name }}</option>
+                        <label for="client_id">Client</label>
+                        <select name="client_id" id="client_id" class="form-control" required="required">
+                            <option value="">Select Client</option>
+                            @foreach ($clients as $client)
+                                <option value="{{ $client->id }}">{{ $client->name }}</option>
                             @endforeach
                         </select>
                     </div>
                     <div class="form-group offset-md-1 col-md-5">
-                        <label for="project_invoice_id">Invoice ID</label>
-                        <input type="text" class="form-control" name="project_invoice_id" id="project_invoice_id" placeholder="Invoice ID" required="required">
+                        <label for="project_id">Project</label>
+                        <select name="project_ids[]" id="project_ids" class="form-control" required="required" multiple="multiple">
+                        </select>
                     </div>
                 </div>
                 <br>
                 <div class="form-row">
                     <div class="form-group col-md-5">
+                        <label for="project_invoice_id">Invoice ID</label>
+                        <input type="text" class="form-control" name="project_invoice_id" id="project_invoice_id" placeholder="Invoice ID" required="required">
+                    </div>
+                    <div class="form-group offset-md-1 col-md-5">
                         <label for="status">Status</label>
                         <select name="status" id="status" class="form-control" required="required">
                         @foreach (config('constants.finance.invoice.status') as $status => $display_name)

--- a/resources/views/finance/invoice/edit.blade.php
+++ b/resources/views/finance/invoice/edit.blade.php
@@ -19,11 +19,17 @@
             <div class="card-body">
                 <div class="form-row">
                     <div class="form-group col-md-5">
+                        @php $invoice_projects = []; @endphp
+                        @foreach ($invoice->projects as $project)
+                            @php
+                                array_push($invoice_projects, $project->id);
+                            @endphp
+                        @endforeach
                         <label for="project_id">Project</label>
-                        <select name="project_id" id="project_id" class="form-control" required="required">
+                        <select name="project_ids[]" id="project_ids" class="form-control" required="required" multiple="multiple">
                             @foreach ($projects as $project)
                                 @php
-                                    $selected = $project->id === $invoice->project_id ? 'selected="selected"' : '';
+                                    $selected = in_array($project->id, $invoice_projects) ? 'selected="selected"' : '';
                                 @endphp
                                 <option value="{{ $project->id }}" {{ $selected }}>{{ $project->name }}</option>
                             @endforeach

--- a/resources/views/finance/invoice/edit.blade.php
+++ b/resources/views/finance/invoice/edit.blade.php
@@ -8,7 +8,7 @@
     <a class="btn btn-info" href="/finance/invoices">See all invoices</a>
     <br><br>
     <div class="card">
-        <form action="/finance/invoices/{{ $invoice->id }}" method="POST" enctype="multipart/form-data">
+        <form action="/finance/invoices/{{ $invoice->id }}" method="POST" enctype="multipart/form-data" id="form_edit_invoice">
 
             {{ csrf_field() }}
             {{ method_field('PATCH') }}
@@ -19,15 +19,27 @@
             <div class="card-body">
                 <div class="form-row">
                     <div class="form-group col-md-5">
+                        <label for="client_id">Client</label>
+                        <select name="client_id" id="client_id" class="form-control" required="required">
+                            <option value="">Select Client</option>
+                            @foreach ($clients as $client)
+                                @php
+                                    $selected = $client->id === $invoice_client->id ? 'selected="selected"' : '';
+                                @endphp
+                                <option value="{{ $client->id }}" {{ $selected }}>{{ $client->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="form-group offset-md-1 col-md-5">
                         @php $invoice_projects = []; @endphp
-                        @foreach ($invoice->projects as $project)
+                        @foreach ($invoice->projects as $invoice_project)
                             @php
-                                array_push($invoice_projects, $project->id);
+                                array_push($invoice_projects, $invoice_project->id);
                             @endphp
                         @endforeach
                         <label for="project_id">Project</label>
                         <select name="project_ids[]" id="project_ids" class="form-control" required="required" multiple="multiple">
-                            @foreach ($projects as $project)
+                            @foreach ($client_projects as $project)
                                 @php
                                     $selected = in_array($project->id, $invoice_projects) ? 'selected="selected"' : '';
                                 @endphp
@@ -35,14 +47,14 @@
                             @endforeach
                         </select>
                     </div>
-                    <div class="form-group offset-md-1 col-md-5">
-                        <label for="project_invoice_id">Invoice ID</label>
-                        <input type="text" class="form-control" name="project_invoice_id" id="project_invoice_id" placeholder="Invoice ID" required="required" value="{{ $invoice->project_invoice_id }}">
-                    </div>
                 </div>
                 <br>
                 <div class="form-row">
                     <div class="form-group col-md-5">
+                        <label for="project_invoice_id">Invoice ID</label>
+                        <input type="text" class="form-control" name="project_invoice_id" id="project_invoice_id" placeholder="Invoice ID" required="required" value="{{ $invoice->project_invoice_id }}">
+                    </div>
+                    <div class="form-group offset-md-1 col-md-5">
                         <label for="name">Status</label>
                         <select name="status" id="status" class="form-control" required="required">
                         @foreach (config('constants.finance.invoice.status') as $status => $display_name)

--- a/resources/views/finance/invoice/index.blade.php
+++ b/resources/views/finance/invoice/index.blade.php
@@ -19,7 +19,11 @@
         </tr>
         @foreach ($invoices as $invoice)
         <tr>
-            <td><a href="/finance/invoices/{{ $invoice->id }}/edit">{{ $invoice->project->name }}</a></td>
+            <td><a href="/finance/invoices/{{ $invoice->id }}/edit">
+                @foreach ($invoice->projects as $project)
+                    {{ $project->name }},
+                @endforeach
+            </a></td>
             <td>
                 @switch ($invoice->status)
                     @case('paid')

--- a/resources/views/finance/invoice/index.blade.php
+++ b/resources/views/finance/invoice/index.blade.php
@@ -21,7 +21,8 @@
         <tr>
             <td><a href="/finance/invoices/{{ $invoice->id }}/edit">
                 @foreach ($invoice->projects as $project)
-                    {{ $project->name }},
+                    {{ $loop->first ? '' : '|' }}
+                    {{ $project->name }}
                 @endforeach
             </a></td>
             <td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,5 +32,6 @@ Route::middleware('auth')->group(function () {
 	Route::resource('clients', 'ClientController');
 	Route::resource('projects', 'ProjectController');
 	Route::get('finance/invoices/download/{year}/{month}/{file}', 'Finance\InvoiceController@download');
+	Route::get('clients/{client}/get-projects', 'ClientController@getProjects');
 });
 


### PR DESCRIPTION
#55 Support for multiple projects

Changes include:
1. Pivot table for project and invoice to store many to many relationships (create migration).
2. Delete foreign key constraint and project_id from `finance_invoices` table (update migration).
3. Added client select field in invoice form.
4. Project select field is now multi-select.
5. When client is changed, the select project field gets updated with the projects associated to the selected client.
6. On invoice listing page, in case there are more than one projects for an invoice, the project names are separated with a `|` (pipe).