### PR TITLE
(#204) duplicate applicant

### DIFF
--- a/app/Http/Controllers/HR/ApplicantController.php
+++ b/app/Http/Controllers/HR/ApplicantController.php
@@ -91,7 +91,6 @@ class ApplicantController extends Controller
         $applicant->load(['applications', 'applications.job.rounds', 'applicantRounds', 'applicantRounds.applicantReviews']);
 
         return view('hr.applicant.edit')->with([
-            // 'job' => $applicant->job,
             'applicant' => $applicant,
             'rounds' => Round::all(),
         ]);

--- a/app/Http/Controllers/HR/ApplicantController.php
+++ b/app/Http/Controllers/HR/ApplicantController.php
@@ -13,19 +13,21 @@ class ApplicantController extends Controller
     /**
      * Display a listing of the resource.
      *@param  \App\Http\Requests\HR\ApplicantRequest  $request
-     * 
+     *
      * @return \Illuminate\View\View
      */
     public function index(ApplicantRequest $request)
-    {  
+    {
         $validated = $request->validated();
         $hrJobID = (isset($validated['hr_job_id'])) ? $validated['hr_job_id'] : null;
-        
-        $applicants = Applicant::with('job')
-                        ->where(function($query) use ($hrJobID ) {
-                            ($hrJobID) ? $query->where('hr_job_id', $hrJobID) : null;
-                        })
-                        ->orderBy('id', 'desc')
+
+        // $applicants = Applicant::with('job')
+        //                 ->where(function($query) use ($hrJobID ) {
+        //                     ($hrJobID) ? $query->where('hr_job_id', $hrJobID) : null;
+        //                 })
+        //                 ->orderBy('id', 'desc')
+        //                 ->paginate(config('constants.pagination_size'));
+        $applicants = Applicant::orderBy('id', 'desc')
                         ->paginate(config('constants.pagination_size'));
 
         return view('hr.applicant.index')->with([
@@ -88,10 +90,10 @@ class ApplicantController extends Controller
      */
     public function edit(Applicant $applicant)
     {
-        $applicant->load(['job', 'job.rounds', 'applicantRounds', 'applicantRounds.applicantReviews']);
+        $applicant->load(['applications', 'applications.job.rounds', 'applicantRounds', 'applicantRounds.applicantReviews']);
 
         return view('hr.applicant.edit')->with([
-            'job' => $applicant->job,
+            // 'job' => $applicant->job,
             'applicant' => $applicant,
             'rounds' => Round::all(),
         ]);

--- a/app/Http/Controllers/HR/ApplicantController.php
+++ b/app/Http/Controllers/HR/ApplicantController.php
@@ -21,13 +21,11 @@ class ApplicantController extends Controller
         $validated = $request->validated();
         $hrJobID = (isset($validated['hr_job_id'])) ? $validated['hr_job_id'] : null;
 
-        // $applicants = Applicant::with('job')
-        //                 ->where(function($query) use ($hrJobID ) {
-        //                     ($hrJobID) ? $query->where('hr_job_id', $hrJobID) : null;
-        //                 })
-        //                 ->orderBy('id', 'desc')
-        //                 ->paginate(config('constants.pagination_size'));
-        $applicants = Applicant::orderBy('id', 'desc')
+        $applicants = Applicant::with('applications', 'applications.job')
+                        ->where(function($query) use ($hrJobID ) {
+                            ($hrJobID) ? $query->where('hr_job_id', $hrJobID) : null;
+                        })
+                        ->orderBy('id', 'desc')
                         ->paginate(config('constants.pagination_size'));
 
         return view('hr.applicant.index')->with([

--- a/app/Http/Controllers/HR/JobController.php
+++ b/app/Http/Controllers/HR/JobController.php
@@ -18,7 +18,7 @@ class JobController extends Controller
     public function index()
     {
         return view('hr.job.index')->with([
-            'jobs' => Job::with('applicants')->orderBy('id', 'desc')->get(),
+            'jobs' => Job::with('applications', 'applications.applicant')->orderBy('id', 'desc')->get(),
         ]);
     }
 

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -5,6 +5,7 @@ namespace App\Models\HR;
 use App\Events\HR\ApplicantCreated;
 use App\Events\HR\ApplicantUpdated;
 use App\Models\HR\ApplicantRound;
+use App\Models\HR\Application;
 use App\Models\HR\Job;
 use Illuminate\Database\Eloquent\Model;
 
@@ -56,6 +57,11 @@ class Applicant extends Model
     public function jobs()
     {
     	return $this->belongsToMany(Job::class, 'hr_applications', 'hr_applicant_id', 'hr_job_id');
+    }
+
+    public function applications()
+    {
+        return $this->belongsToMany(Application::class, 'hr_applications', 'hr_applicant_id')
     }
 
     public function applicantRounds()

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -24,6 +24,10 @@ class Applicant extends Model
     public static function _create($attr)
     {
         $applicant = self::create($attr);
+        $application = Application::create([
+            'hr_job_id' => $attr['hr_job_id'],
+            'hr_applicant_id' => $applicant->id
+        ]);
         event(new ApplicantCreated($applicant));
         return $applicant;
     }
@@ -51,17 +55,9 @@ class Applicant extends Model
         return $this->applicantRounds->where('hr_round_id', $round_id)->first();
     }
 
-    /**
-     * Get the jobs that belong to the applicant
-     */
-    public function jobs()
-    {
-    	return $this->belongsToMany(Job::class, 'hr_applications', 'hr_applicant_id', 'hr_job_id');
-    }
-
     public function applications()
     {
-        return $this->belongsToMany(Application::class, 'hr_applications', 'hr_applicant_id')
+        return $this->hasMany(Application::class, 'hr_applicant_id');
     }
 
     public function applicantRounds()

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -55,7 +55,7 @@ class Applicant extends Model
      */
     public function jobs()
     {
-    	return $this->belongsToMany(Job::class, 'hr_applicant_job', 'hr_applicant_id', 'hr_job_id');
+    	return $this->belongsToMany(Job::class, 'hr_applications', 'hr_applicant_id', 'hr_job_id');
     }
 
     public function applicantRounds()

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -50,9 +50,12 @@ class Applicant extends Model
         return $this->applicantRounds->where('hr_round_id', $round_id)->first();
     }
 
-    public function job()
+    /**
+     * Get the jobs that belong to the applicant
+     */
+    public function jobs()
     {
-    	return $this->belongsTo(Job::class, 'hr_job_id');
+    	return $this->belongsToMany(Job::class, 'hr_applicant_job', 'hr_applicant_id', 'hr_job_id');
     }
 
     public function applicantRounds()

--- a/app/Models/HR/ApplicantRound.php
+++ b/app/Models/HR/ApplicantRound.php
@@ -41,7 +41,7 @@ class ApplicantRound extends Model
         }
 
         if ($nextRound) {
-            $scheduled_person = User::findByEmail($applicant->job->posted_by);
+            $scheduled_person = User::findByEmail($applicant->applications->first()->job->posted_by);
             $applicantRound = self::_create([
                 'hr_applicant_id' => $applicant->id,
                 'hr_round_id' => $nextRound,

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\HR;
 
+use App\Models\HR\Job;
 use Illuminate\Database\Eloquent\Model;
 
 class Application extends Model
@@ -9,4 +10,9 @@ class Application extends Model
     protected $guarded = ['id'];
 
     protected $table = 'hr_applications';
+
+    public function job()
+    {
+    	return $this->belongsTo(Job::class, 'hr_job_id');
+    }
 }

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\HR;
 
+use App\Models\HR\Applicant;
 use App\Models\HR\Job;
 use Illuminate\Database\Eloquent\Model;
 
@@ -14,5 +15,10 @@ class Application extends Model
     public function job()
     {
     	return $this->belongsTo(Job::class, 'hr_job_id');
+    }
+
+    public function applicant()
+    {
+        return $this->belongsTo(Applicant::class, 'hr_applicant_id');
     }
 }

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models\HR;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Application extends Model
+{
+    protected $guarded = ['id'];
+
+    protected $table = 'hr_applications';
+}

--- a/app/Models/HR/Job.php
+++ b/app/Models/HR/Job.php
@@ -49,7 +49,7 @@ class Job extends Model
 
     public function applications()
     {
-    	return $this->belongsToMany(Application::class, 'hr_applications', 'hr_job_id');
+    	return $this->hasMany(Application::class, 'hr_job_id');
     }
 
     public function getApplicantsByStatus($status = '')

--- a/app/Models/HR/Job.php
+++ b/app/Models/HR/Job.php
@@ -39,7 +39,7 @@ class Job extends Model
         if(isset($attr['rounds'])) {
             $this->rounds()->sync($attr['rounds']);
         }
-        
+
         $request = request();
         event(new JobUpdated($this, [
             'rounds' => $request->input('rounds'),
@@ -47,9 +47,9 @@ class Job extends Model
         return $updated;
     }
 
-    public function applicants()
+    public function applications()
     {
-    	return $this->hasMany(Applicant::class, 'hr_job_id');
+    	return $this->belongsToMany(Application::class, 'hr_applications', 'hr_job_id');
     }
 
     public function getApplicantsByStatus($status = '')

--- a/database/migrations/2018_05_14_083216_create_hr_applicant_job_table.php
+++ b/database/migrations/2018_05_14_083216_create_hr_applicant_job_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateHrApplicantJobTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('hr_applicant_job', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('hr_applicant_id');
+            $table->unsignedInteger('hr_job_id');
+            $table->timestamps();
+        });
+
+        Schema::table('hr_applicant_job', function (Blueprint $table) {
+            $table->foreign('hr_applicant_id')->references('id')->on('hr_applicants');
+            $table->foreign('hr_job_id')->references('id')->on('hr_jobs');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('hr_applicant_job', function (Blueprint $table) {
+            $table->dropForeign([
+                'hr_applicant_id',
+                'hr_job_id',
+            ]);
+        });
+    }
+}

--- a/database/migrations/2018_05_14_083216_create_hr_applications_table.php
+++ b/database/migrations/2018_05_14_083216_create_hr_applications_table.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateHrApplicantJobTable extends Migration
+class CreateHrApplicationsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,14 +13,14 @@ class CreateHrApplicantJobTable extends Migration
      */
     public function up()
     {
-        Schema::create('hr_applicant_job', function (Blueprint $table) {
+        Schema::create('hr_applications', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('hr_applicant_id');
             $table->unsignedInteger('hr_job_id');
             $table->timestamps();
         });
 
-        Schema::table('hr_applicant_job', function (Blueprint $table) {
+        Schema::table('hr_applications', function (Blueprint $table) {
             $table->foreign('hr_applicant_id')->references('id')->on('hr_applicants');
             $table->foreign('hr_job_id')->references('id')->on('hr_jobs');
         });
@@ -33,7 +33,7 @@ class CreateHrApplicantJobTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('hr_applicant_job', function (Blueprint $table) {
+        Schema::dropIfExists('hr_applications', function (Blueprint $table) {
             $table->dropForeign([
                 'hr_applicant_id',
                 'hr_job_id',

--- a/database/seeds/MigrateApplicantJobReferenceSeeder.php
+++ b/database/seeds/MigrateApplicantJobReferenceSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\HR\Applicant;
+use App\Models\HR\Application;
 use Illuminate\Database\Seeder;
 
 class MigrateApplicantJobReferenceSeeder extends Seeder
@@ -17,34 +18,38 @@ class MigrateApplicantJobReferenceSeeder extends Seeder
         $uniqueApplicants = [];
         foreach ($applicants as $applicant) {
 
-        	// checking if the current applicant entry is duplicate
-        	if (array_key_exists($applicant->email, $uniqueApplicants)) {
+            // checking if the current applicant entry is duplicate
+            if (array_key_exists($applicant->email, $uniqueApplicants)) {
 
-        		// find the original applicant with the same email. $applicant is duplicate of $originalApplicant
-        		$originalApplicant = $uniqueApplicants[$applicant->email];
+                // find the original applicant with the same email. $applicant is duplicate of $originalApplicant
+                $originalApplicant = $uniqueApplicants[$applicant->email];
 
-        		// add the job of this duplicate applicant as the job of original applicant
-        		$originalApplicant->jobs()->attach($applicant->hr_job_id, [
-        			'created_at' => $applicant->created_at,
-        			'updated_at' => $applicant->updated_at,
-        		]);
+                // add the job of this duplicate applicant as the job of original applicant
+                Application::create([
+                    'hr_job_id' => $applicant->hr_job_id,
+                    'hr_applicant_id' => $originalApplicant->id,
+                    'created_at' => $applicant->created_at,
+                    'updated_at' => $applicant->updated_at,
+                ]);
 
-        		foreach($applicant->applicantRounds as $applicantRound) {
-        			foreach ($applicantRound->applicantReviews as $applicantReview) {
-        				echo $applicantReview->id;
-        				$applicantReview->delete();
-        			}
-        			$applicantRound->delete();
-        		}
-        		$applicant->delete();
+                foreach($applicant->applicantRounds as $applicantRound) {
+                    foreach ($applicantRound->applicantReviews as $applicantReview) {
+                        echo $applicantReview->id;
+                        $applicantReview->delete();
+                    }
+                    $applicantRound->delete();
+                }
+                $applicant->delete();
 
-        		continue;
-        	}
-        	$uniqueApplicants[$applicant->email] = $applicant;
-        	$applicant->jobs()->attach($applicant->hr_job_id, [
-        		'created_at' => $applicant->created_at,
-    			'updated_at' => $applicant->updated_at,
-        	]);
+                continue;
+            }
+            $uniqueApplicants[$applicant->email] = $applicant;
+            Application::create([
+                'hr_job_id' => $applicant->hr_job_id,
+                'hr_applicant_id' => $applicant->id,
+                'created_at' => $applicant->created_at,
+                'updated_at' => $applicant->updated_at,
+            ]);
         }
     }
 }

--- a/database/seeds/MigrateApplicantJobReferenceSeeder.php
+++ b/database/seeds/MigrateApplicantJobReferenceSeeder.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\HR\Applicant;
+use Illuminate\Database\Seeder;
+
+class MigrateApplicantJobReferenceSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $applicants = Applicant::all();
+
+        $uniqueApplicants = [];
+        foreach ($applicants as $applicant) {
+
+        	// checking if the current applicant entry is duplicate
+        	if (array_key_exists($applicant->email, $uniqueApplicants)) {
+
+        		// find the original applicant with the same email. $applicant is duplicate of $originalApplicant
+        		$originalApplicant = $uniqueApplicants[$applicant->email];
+
+        		// add the job of this duplicate applicant as the job of original applicant
+        		$originalApplicant->jobs()->attach($applicant->hr_job_id, [
+        			'created_at' => $applicant->created_at,
+        			'updated_at' => $applicant->updated_at,
+        		]);
+
+        		foreach($applicant->applicantRounds as $applicantRound) {
+        			foreach ($applicantRound->applicantReviews as $applicantReview) {
+        				echo $applicantReview->id;
+        				$applicantReview->delete();
+        			}
+        			$applicantRound->delete();
+        		}
+        		$applicant->delete();
+
+        		continue;
+        	}
+        	$uniqueApplicants[$applicant->email] = $applicant;
+        	$applicant->jobs()->attach($applicant->hr_job_id, [
+        		'created_at' => $applicant->created_at,
+    			'updated_at' => $applicant->updated_at,
+        	]);
+        }
+    }
+}

--- a/resources/views/hr/applicant/edit.blade.php
+++ b/resources/views/hr/applicant/edit.blade.php
@@ -36,7 +36,9 @@
                         </div>
                         <div class="form-group offset-md-1 col-md-5">
                             <b>Applied for</b>
-                            <div><a href="{{ $applicant->job->link }}" target="_blank">{{ $applicant->job->title }}</a></div>
+                            @foreach($applicant->applications as $application)
+                                <div><a href="{{ $application->job->link }}" target="_blank">{{ $application->job->title }}</a></div>
+                            @endforeach
                         </div>
                         <div class="form-group col-md-5">
                             <b>Phone</b>
@@ -118,7 +120,7 @@
                         @if (! $applicantRound->round_status)
                         <div class="card-footer">
                             <applicant-round-action-component
-                            :rounds="{{ json_encode($job->rounds) }}">
+                            :rounds="{{ json_encode($application->job->first()->rounds) }}">
                             </applicant-round-action-component>
                             <button type="button" class="btn btn-outline-danger round-submit" data-status="{{ config('constants.hr.status.rejected.label') }}">Reject</button>
                         </div>
@@ -126,7 +128,7 @@
                         <div class="card-footer">
                             @if ($applicantRound->round_status === config('constants.hr.status.rejected.label'))
                                 <applicant-round-action-component
-                                :rounds="{{ json_encode($job->rounds) }}">
+                                :rounds="{{ json_encode($application->job->first()->rounds) }}">
                                 </applicant-round-action-component>
                             @endif
                             @if (!$applicantRound->mail_sent)

--- a/resources/views/hr/applicant/index.blade.php
+++ b/resources/views/hr/applicant/index.blade.php
@@ -20,7 +20,11 @@
                 <a href="/hr/applicants/{{ $applicant->id }}/edit">{{ $applicant->name }}</a>
             </td>
             <td>{{ $applicant->email }}</td>
-            <td>{{ $applicant->job->title }}</td>
+            <td>
+                @foreach($applicant->applications as $application)
+                    {{ $application->job->title }}
+                @endforeach
+            </td>
             <td>{{ $applicant->created_at->format(config('constants.display_date_format')) }}</td>
             <td>
                 <span class="d-flex justify-content-start">

--- a/resources/views/hr/applicant/timeline.blade.php
+++ b/resources/views/hr/applicant/timeline.blade.php
@@ -2,8 +2,10 @@
     <div class="timeline-container">
         <div class="content">
             <b><u>{{ date(config('constants.display_date_format'), strtotime($applicant->created_at)) }}</u></b><br>
-            Applied for {{ $applicant->job->title }}
-            <br>
+            Applied for
+            @foreach($applicant->applications as $application)
+                <div>{{ $application->job->title }}</div>
+            @endforeach
             @if ($applicant->autoresponder_subject && $applicant->autoresponder_body)
                 <span data-toggle="modal" data-target="#autoresponder_mail" class="modal-toggler-text text-primary">Auto-respond mail for system</span>
                 @include('hr.applicant.auto-respond', ['applicant' => $applicant])

--- a/resources/views/hr/job/index.blade.php
+++ b/resources/views/hr/job/index.blade.php
@@ -21,11 +21,11 @@
                 <a href="{{ $job->link }}" target="_blank">See</a>
             </td>
             <td>
-                @if($job->applicants->count())
-                <a href="/hr/applicants?hr_job_id={{$job->id }}">{{ $job->applicants->count() }}</a>
-                @else 
-                {{ $job->applicants->count() }}
-                @endif
+            @if ($job->applications->count())
+                <a href="/hr/applicants?hr_job_id={{$job->id }}">{{ $job->applications->count() }}</a>
+            @else
+                {{ $job->applications->count() }}
+            @endif
             </td>
         </tr>
         @endforeach


### PR DESCRIPTION
#204 

Changes include:

1. Instead of associating applicant with a job, there'll be multiple applications for an applicant that will be associated with a job.
2. Migration for `hr_applications` table (which is a many-to-many relationship table between applicant and job).
3. Seeder to make applications for every unique applicant and then deleting the duplicate applicants.

Changes related to this issue targeted in next (tomorrow's) PR:
1. A new applicant won't be created if he/she is applying again (for the same or different job). Instead, a new application will be created.
2. Reason for eligibility, resume, and some other fields can be different for each application. Hence these details will be stored in `hr_applications` table.
3. `hr_applicant_round` will be renamed to `hr_application_round`. Will reference application_id instead of applicant_id.
4. `hr_applicant_reviews` will be renamed to `hr_application_review`. Will reference application_round_id instead of applicant_round_id.
5. The applicant edit screen will be replaced by application edit screen.


This means right now, if an applicant applies again, a new applicant will still be added along with a new application.

Commands to run:
```
$ php artisan migrate
$ php artisan db:seed --class=MigrateApplicantJobReferenceSeeder
```