### PR TITLE
(#204) applicant changes

### DIFF
--- a/app/Http/Controllers/HR/ApplicantController.php
+++ b/app/Http/Controllers/HR/ApplicantController.php
@@ -50,19 +50,9 @@ class ApplicantController extends Controller
         $validated = $request->validated();
         $job = Job::where('title', $validated['job_title'])->first();
 
-        return Applicant::_create([
-            'name' => $validated['name'],
-            'email' => $validated['email'],
-            'resume' => $validated['resume'],
-            'phone' => isset($validated['phone']) ? $validated['phone'] : null,
-            'college' => isset($validated['college']) ? $validated['college'] : null,
-            'graduation_year' => isset($validated['graduation_year']) ? $validated['graduation_year'] : null,
-            'course' => isset($validated['course']) ? $validated['course'] : null,
-            'linkedin' => isset($validated['linkedin']) ? $validated['linkedin'] : null,
-            'reason_for_eligibility' => isset($validated['reason_for_eligibility']) ? $validated['reason_for_eligibility'] : null,
-            'hr_job_id' => $job->id,
-            'status' => config('constants.hr.status.new.label'),
-        ]);
+        $applicant = Applicant::_create($validated);
+
+        return $applicant;
     }
 
     /**

--- a/app/Http/Controllers/HR/ApplicantController.php
+++ b/app/Http/Controllers/HR/ApplicantController.php
@@ -5,8 +5,6 @@ namespace App\Http\Controllers\HR;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\HR\ApplicantRequest;
 use App\Models\HR\Applicant;
-use App\Models\HR\Job;
-use App\Models\HR\Round;
 
 class ApplicantController extends Controller
 {
@@ -48,11 +46,7 @@ class ApplicantController extends Controller
     public function store(ApplicantRequest $request)
     {
         $validated = $request->validated();
-        $job = Job::where('title', $validated['job_title'])->first();
-
-        $applicant = Applicant::_create($validated);
-
-        return $applicant;
+        return Applicant::_create($validated);
     }
 
     /**

--- a/app/Http/Controllers/HR/ApplicationController.php
+++ b/app/Http/Controllers/HR/ApplicationController.php
@@ -77,12 +77,13 @@ class ApplicationController extends Controller
      */
     public function edit(Application $application)
     {
-        $application->load(['job.rounds', 'applicant', 'applicant.applications', 'applicationRounds']);
+        $application->load(['job.rounds', 'applicant', 'applicant.applications', 'applicationRounds', 'applicationRounds.round']);
 
         return view('hr.application.edit')->with([
             'applicant' => $application->applicant,
             'application' => $application,
             'rounds' => Round::all(),
+            'applicantOpenApplications' => $application->applicant->openApplications(),
         ]);
     }
 

--- a/app/Http/Controllers/HR/ApplicationController.php
+++ b/app/Http/Controllers/HR/ApplicationController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\HR\Application;
 use App\Models\HR\Round;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Input;
 
 class ApplicationController extends Controller
 {
@@ -17,7 +18,7 @@ class ApplicationController extends Controller
     public function index()
     {
         return view('hr.application.index')->with([
-            'applications' => self::getApplicationsList(),
+            'applications' => Application::filterByStatus(request()->get('status'))->appends(Input::except('page')),
             'status' => request()->get('status'),
         ]);
     }
@@ -108,25 +109,5 @@ class ApplicationController extends Controller
     public function destroy(Application $application)
     {
         //
-    }
-
-    /**
-     * get list of applications based on their show status
-     * @return \Illuminate\Database\Eloquent\Collection
-     */
-    public function getApplicationsList()
-    {
-        $request = request();
-        $applications = Application::with('applicant', 'job');
-        $rejected = config('constants.hr.status.rejected.label');
-        switch ($request->get('status')) {
-            case $rejected:
-                $applications = $applications->where('status', $rejected);
-                break;
-            default:
-                $applications = $applications->where('status', '!=', $rejected);
-                break;
-        }
-        return $applications->orderBy('id', 'desc')->paginate(config('constants.pagination_size'));
     }
 }

--- a/app/Http/Controllers/HR/ApplicationController.php
+++ b/app/Http/Controllers/HR/ApplicationController.php
@@ -16,10 +16,9 @@ class ApplicationController extends Controller
      */
     public function index()
     {
-        $applications = Application::with('applicant', 'job')->orderBy('id', 'desc')->paginate(config('constants.pagination_size'));
-
         return view('hr.application.index')->with([
-            'applications' => $applications,
+            'applications' => self::getApplicationsList(),
+            'status' => request()->get('status'),
         ]);
     }
 
@@ -108,5 +107,24 @@ class ApplicationController extends Controller
     public function destroy(Application $application)
     {
         //
+    }
+
+    /**
+     * get list of applications based on their show status
+     * @return [type] [description]
+     */
+    public function getApplicationsList()
+    {
+        $request = request();
+        $applications = Application::with('applicant', 'job');
+        switch ($request->get('status')) {
+            case 'rejected':
+                $applications = $applications->where('status', 'rejected');
+                break;
+            default:
+                $applications = $applications->where('status', '!=', 'rejected');
+                break;
+        }
+        return $applications->orderBy('id', 'desc')->paginate(config('constants.pagination_size'));
     }
 }

--- a/app/Http/Controllers/HR/ApplicationController.php
+++ b/app/Http/Controllers/HR/ApplicationController.php
@@ -112,18 +112,19 @@ class ApplicationController extends Controller
 
     /**
      * get list of applications based on their show status
-     * @return [type] [description]
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getApplicationsList()
     {
         $request = request();
         $applications = Application::with('applicant', 'job');
+        $rejected = config('constants.hr.status.rejected.label');
         switch ($request->get('status')) {
-            case 'rejected':
-                $applications = $applications->where('status', 'rejected');
+            case $rejected:
+                $applications = $applications->where('status', $rejected);
                 break;
             default:
-                $applications = $applications->where('status', '!=', 'rejected');
+                $applications = $applications->where('status', '!=', $rejected);
                 break;
         }
         return $applications->orderBy('id', 'desc')->paginate(config('constants.pagination_size'));

--- a/app/Http/Controllers/HR/ApplicationRoundController.php
+++ b/app/Http/Controllers/HR/ApplicationRoundController.php
@@ -5,11 +5,12 @@ namespace App\Http\Controllers\HR;
 use App\Helpers\ContentHelper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\HR\ApplicantRoundMailRequest;
-use App\Http\Requests\HR\ApplicantRoundRequest;
+use App\Http\Requests\HR\ApplicationRoundRequest;
 use App\Mail\HR\Applicant\RoundReviewed;
 use App\Models\HR\ApplicantRound;
 use App\Models\HR\ApplicationRound;
 use Carbon\Carbon;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Mail;
 
@@ -17,19 +18,13 @@ class ApplicationRoundController extends Controller
 {
     /**
      * Update the specified resource in storage.
-     * @param  ApplicantRoundRequest $request
+     * @param  ApplicationRoundRequest $request
      * @param  ApplicationRound        $round
      * @return \Illuminate\Http\Response
      */
-    public function update(ApplicantRoundRequest $request, ApplicationRound $round)
+    public function update(ApplicationRoundRequest $request, ApplicationRound $round)
     {
-        $validated = $request->validated();
-        $round->_update([
-            'round_status' => $validated['round_status'],
-            'conducted_person_id' => Auth::id(),
-            'conducted_date' => Carbon::now(),
-        ], $validated['action_type'], $validated['reviews'], $validated['next_round']);
-
+        $round->_update($request->validated());
         return redirect('/hr/applications/' . $round->application->id . '/edit')->with('status', 'Application updated successfully!');
     }
 

--- a/app/Http/Requests/HR/ApplicationRoundRequest.php
+++ b/app/Http/Requests/HR/ApplicationRoundRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests\HR;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class ApplicantRoundRequest extends FormRequest
+class ApplicationRoundRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -25,9 +25,9 @@ class ApplicantRoundRequest extends FormRequest
     {
         return [
             'reviews' => 'nullable',
-            'action_type' => 'required|string',
-            'round_status' => 'nullable|string|required_if:action_type,new',
-            'next_round' => 'nullable|string',
+            'action' => 'required|string',
+            'next_round' => 'nullable|string|required_if:action,confirm',
+            'refer_to' => 'nullable|string|required_if:action,refer'
         ];
     }
 }

--- a/app/Listeners/HR/CreateFirstApplicationRound.php
+++ b/app/Listeners/HR/CreateFirstApplicationRound.php
@@ -33,7 +33,6 @@ class CreateFirstApplicationRound
         $scheduledPerson = User::findByEmail($job->posted_by);
 
         $applicationRound = ApplicationRound::_create([
-            'hr_applicant_id' => $application->applicant->id,
             'hr_application_id' => $application->id,
             'hr_round_id' => $job->rounds->first()->id,
             'scheduled_date' => Carbon::now()->addDay(),

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -23,15 +23,25 @@ class Applicant extends Model
      */
     public static function _create($attr)
     {
-        $applicant = self::create($attr);
-        $application = Application::create([
+        $applicant = self::firstOrCreate([
+            'email' => $attr['email'],
+        ], [
+            'name' => $attr['name'],
+            'phone' => isset($attr['phone']) ? $attr['phone'] : null,
+            'college' => isset($attr['college']) ? $attr['college'] : null,
+            'graduation_year' => isset($attr['graduation_year']) ? $attr['graduation_year'] : null,
+            'course' => isset($attr['course']) ? $attr['course'] : null,
+            'linkedin' => isset($attr['linkedin']) ? $attr['linkedin'] : null,
+        ]);
+
+        $application = Application::_create([
             'hr_job_id' => $attr['hr_job_id'],
             'hr_applicant_id' => $applicant->id,
             'resume' => $attr['resume'],
             'reason_for_eligibility' => isset($attr['reason_for_eligibility']) ? $attr['reason_for_eligibility'] : null,
             'status' => config('constants.hr.status.new.label'),
         ]);
-        event(new ApplicationCreated($application));
+
         return $applicant;
     }
 
@@ -51,11 +61,6 @@ class Applicant extends Model
             'reviews' => $request->input('reviews'),
         ]));
         return $updated;
-    }
-
-    public function getApplicantRound($round_id)
-    {
-        return $this->applicantRounds->where('hr_round_id', $round_id)->first();
     }
 
     public function applications()

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -44,15 +44,9 @@ class Applicant extends Model
         return $applicant;
     }
 
-    /**
-     * Custom update method that updates an applicant and fires specific events
-     *
-     * @param  array $attr       fillables to be updated
-     * @return boolean|object    true if update is successful, error object if update fails
-     */
-    public function _update($attr)
+    public function openApplications()
     {
-        //
+        return $this->applications->where('status', '!=', config('constants.hr.status.rejected.label'));
     }
 
     public function applications()

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -31,13 +31,14 @@ class Applicant extends Model
             'linkedin' => isset($attr['linkedin']) ? $attr['linkedin'] : null,
         ]);
 
+        $applicationStatus = $applicant->wasRecentlyCreated ? config('constants.hr.status.new.label') : config('constants.hr.status.on-hold.label');
         $job = Job::where('title', $attr['job_title'])->first();
         $application = Application::_create([
             'hr_job_id' => $job->id,
             'hr_applicant_id' => $applicant->id,
             'resume' => $attr['resume'],
             'reason_for_eligibility' => isset($attr['reason_for_eligibility']) ? $attr['reason_for_eligibility'] : null,
-            'status' => config('constants.hr.status.new.label'),
+            'status' => $applicationStatus,
         ]);
 
         return $applicant;

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -48,7 +48,7 @@ class Applicant extends Model
      */
     public function openApplications()
     {
-        return $this->applications->where('status', '!=', config('constants.hr.status.rejected.label'));
+        return $this->applications()->nonRejected()->get();
     }
 
     public function applications()

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -2,9 +2,6 @@
 
 namespace App\Models\HR;
 
-use App\Events\HR\ApplicationCreated;
-use App\Events\HR\ApplicantUpdated;
-use App\Models\HR\ApplicantRound;
 use App\Models\HR\Application;
 use App\Models\HR\Job;
 use Illuminate\Database\Eloquent\Model;
@@ -34,8 +31,9 @@ class Applicant extends Model
             'linkedin' => isset($attr['linkedin']) ? $attr['linkedin'] : null,
         ]);
 
+        $job = Job::where('title', $attr['job_title'])->first();
         $application = Application::_create([
-            'hr_job_id' => $attr['hr_job_id'],
+            'hr_job_id' => $job->id,
             'hr_applicant_id' => $applicant->id,
             'resume' => $attr['resume'],
             'reason_for_eligibility' => isset($attr['reason_for_eligibility']) ? $attr['reason_for_eligibility'] : null,
@@ -53,14 +51,7 @@ class Applicant extends Model
      */
     public function _update($attr)
     {
-        $updated = $this->update($attr);
-        $request = request();
-        event(new ApplicantUpdated($this, [
-            'round_id' => $request->input('round_id'),
-            'round_status' => $request->input('round_status'),
-            'reviews' => $request->input('reviews'),
-        ]));
-        return $updated;
+        //
     }
 
     public function applications()

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -31,19 +31,21 @@ class Applicant extends Model
             'linkedin' => isset($attr['linkedin']) ? $attr['linkedin'] : null,
         ]);
 
-        $applicationStatus = $applicant->wasRecentlyCreated ? config('constants.hr.status.new.label') : config('constants.hr.status.on-hold.label');
         $job = Job::where('title', $attr['job_title'])->first();
         $application = Application::_create([
             'hr_job_id' => $job->id,
             'hr_applicant_id' => $applicant->id,
             'resume' => $attr['resume'],
             'reason_for_eligibility' => isset($attr['reason_for_eligibility']) ? $attr['reason_for_eligibility'] : null,
-            'status' => $applicationStatus,
+            'status' => $applicant->wasRecentlyCreated ? config('constants.hr.status.new.label') : config('constants.hr.status.on-hold.label'),
         ]);
 
         return $applicant;
     }
 
+    /**
+     * Get all applications for the applicant which are not rejected
+     */
     public function openApplications()
     {
         return $this->applications->where('status', '!=', config('constants.hr.status.rejected.label'));

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -32,7 +32,7 @@ class Application extends Model
      */
     public function reject()
     {
-        $this->update(['status' => 'rejected']);
+        $this->update(['status' => config('constants.hr.status.rejected.label')]);
     }
 
     /**
@@ -40,7 +40,7 @@ class Application extends Model
      */
     public function markInProgress()
     {
-        $this->update(['status' => 'in-progress']);
+        $this->update(['status' => config('constants.hr.status.in-progress.label')]);
     }
 
     public function job()

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -28,6 +28,39 @@ class Application extends Model
     }
 
     /**
+     * get applications where status is rejected
+     */
+    public function scopeRejected($query)
+    {
+        return $query->where('status', config('constants.hr.status.rejected.label'));
+    }
+
+    /**
+     * get applications where status is not rejected
+     */
+    public function scopeNonRejected($query)
+    {
+        return $query->where('status', '!=', config('constants.hr.status.rejected.label'));
+    }
+
+    /**
+     * get list of applications based on their show status
+     */
+    public static function filterByStatus($status)
+    {
+        $applications = self::with('applicant', 'job');
+        switch ($status) {
+            case config('constants.hr.status.rejected.label'):
+                $applications = $applications->rejected();
+                break;
+            default:
+                $applications = $applications->nonRejected();
+                break;
+        }
+        return $applications->orderBy('id', 'desc')->paginate(config('constants.pagination_size'));
+    }
+
+    /**
      * Set application status to rejected
      */
     public function reject()

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\HR;
 
+use App\Events\HR\ApplicationCreated;
 use App\Models\HR\Applicant;
 use App\Models\HR\ApplicationRound;
 use App\Models\HR\Job;

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -27,6 +27,22 @@ class Application extends Model
         return $application;
     }
 
+    /**
+     * Set application status to rejected
+     */
+    public function reject()
+    {
+        $this->update(['status' => 'rejected']);
+    }
+
+    /**
+     * Set application status to in-progress
+     */
+    public function markInProgress()
+    {
+        $this->update(['status' => 'in-progress']);
+    }
+
     public function job()
     {
     	return $this->belongsTo(Job::class, 'hr_job_id');

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -13,6 +13,19 @@ class Application extends Model
 
     protected $table = 'hr_applications';
 
+    /**
+     * Custom create method that creates an application and fires necessary events
+     *
+     * @param  array $attr  fillables to be stored
+     * @return this
+     */
+    public static function _create($attr)
+    {
+        $application = self::create($attr);
+        event(new ApplicationCreated($application));
+        return $application;
+    }
+
     public function job()
     {
     	return $this->belongsTo(Job::class, 'hr_job_id');

--- a/app/Models/HR/ApplicationRound.php
+++ b/app/Models/HR/ApplicationRound.php
@@ -2,7 +2,6 @@
 
 namespace App\Models\HR;
 
-use App\Models\HR\Applicant;
 use App\Models\HR\ApplicationReview;
 use App\Models\HR\Round;
 use App\User;
@@ -11,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ApplicationRound extends Model
 {
-    protected $fillable = ['hr_applicant_id', 'hr_application_id', 'hr_round_id', 'scheduled_data', 'scheduled_person_id', 'conducted_date', 'conducted_person_id', 'round_status', 'mail_sent', 'mail_subject', 'mail_body', 'mail_sender', 'mail_sent_at'];
+    protected $fillable = ['hr_application_id', 'hr_round_id', 'scheduled_data', 'scheduled_person_id', 'conducted_date', 'conducted_person_id', 'round_status', 'mail_sent', 'mail_subject', 'mail_body', 'mail_sender', 'mail_sent_at'];
 
     protected $table = 'hr_application_round';
 
@@ -45,7 +44,6 @@ class ApplicationRound extends Model
             $nextJobRound = $application->job->rounds->where('id', $nextRound)->first();
             $scheduledPersonId = $nextJobRound->pivot->hr_round_interviewer_id;
             $applicationRound = self::_create([
-                'hr_applicant_id' => $applicant->id,
                 'hr_application_id' => $application->id,
                 'hr_round_id' => $nextRound,
                 'scheduled_date' => Carbon::now()->addDay(),
@@ -62,7 +60,6 @@ class ApplicationRound extends Model
                     'hr_application_round_id' => $this->id,
                 ],
                 [
-                    'hr_applicant_round_id' => $this->id,
                     'review_key' => $review_key,
                     'review_value' => $review_value,
                 ]

--- a/config/constants.php
+++ b/config/constants.php
@@ -27,6 +27,11 @@ return [
                 'title' => 'New',
                 'class' => 'badge badge-info'
             ],
+            'on-hold' => [
+                'label' => 'on-hold',
+                'title' => 'On hold',
+                'class' => 'badge badge-secondary'
+            ],
             'rejected' => [
                 'label' => 'rejected',
                 'title' => 'Rejected',

--- a/database/migrations/2018_05_16_083123_dropapplicantcolumns.php
+++ b/database/migrations/2018_05_16_083123_dropapplicantcolumns.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class Dropapplicantcolumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('hr_applicants', function(Blueprint $table) {
+            $table->dropColumn([
+                'reason_for_eligibility',
+                'autoresponder_subject',
+                'autoresponder_body',
+                'status',
+                'resume'
+            ]);
+        });
+
+        Schema::table('hr_application_reviews', function(Blueprint $table) {
+            $table->dropColumn(['hr_applicant_round_id']);
+        });
+
+        Schema::table('hr_application_round', function(Blueprint $table) {
+            $table->dropColumn(['hr_applicant_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('hr_application_round', function(Blueprint $table) {
+            $table->unsignedInteger('hr_applicant_id')->nullable();
+        });
+
+        Schema::table('hr_application_reviews', function(Blueprint $table) {
+            $table->unsignedInteger('hr_applicant_round_id')->nullable();
+        });
+
+        Schema::table('hr_applicants', function(Blueprint $table) {
+            $table->string('status')->nullable();
+            $table->string('resume')->nullable();
+            $table->text('reason_for_eligibility')->nullable();
+            $table->string('autoresponder_subject')->nullable();
+            $table->text('autoresponder_body')->nullable();
+        });
+    }
+}

--- a/database/migrations/2018_05_16_083123_dropapplicantcolumns.php
+++ b/database/migrations/2018_05_16_083123_dropapplicantcolumns.php
@@ -14,12 +14,14 @@ class Dropapplicantcolumns extends Migration
     public function up()
     {
         Schema::table('hr_applicants', function(Blueprint $table) {
+            $table->dropForeign(['hr_job_id']);
             $table->dropColumn([
                 'reason_for_eligibility',
                 'autoresponder_subject',
                 'autoresponder_body',
                 'status',
-                'resume'
+                'resume',
+                'hr_job_id'
             ]);
         });
 
@@ -53,6 +55,8 @@ class Dropapplicantcolumns extends Migration
             $table->text('reason_for_eligibility')->nullable();
             $table->string('autoresponder_subject')->nullable();
             $table->text('autoresponder_body')->nullable();
+            $table->unsignedInteger('hr_job_id')->nullable();
+            $table->foreign('hr_job_id')->references('id')->on('hr_jobs');
         });
     }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -148,14 +148,7 @@ if (document.getElementById('finance_report')) {
 
 $('#page_hr_applicant_edit .applicant-round-form').on('click', '.round-submit', function(){
     var form = $(this).closest('.applicant-round-form');
-    form.find('[name="round_status"]').val($(this).data('status'));
-    form.find('[name="next_round"]').val($(this).data('next-round'));
-    form.submit();
-});
-
-$('#page_hr_applicant_edit .applicant-round-form').on('click', '.round-update', function(){
-    var form = $(this).closest('.applicant-round-form');
-    form.find('[name="action_type"]').val('update');
+    form.find('[name="action"]').val($(this).data('action'));
     form.submit();
 });
 

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -111,23 +111,42 @@
                             </div>
                             @if ($applicationRound->round_status)
                                 <div class="form-row float-right">
-                                    <button type="button" class="btn btn-info btn-sm round-update">Update feedback</button>
+                                    <button type="button" class="btn btn-info btn-sm round-submit" data-action="update">Update feedback</button>
                                 </div>
                             @endif
                         </div>
                         @if (! $applicationRound->round_status)
                         <div class="card-footer">
-                            <applicant-round-action-component
-                            :rounds="{{ json_encode($application->job->first()->rounds) }}">
-                            </applicant-round-action-component>
-                            <button type="button" class="btn btn-outline-danger round-submit" data-status="{{ config('constants.hr.status.rejected.label') }}">Reject</button>
+                            <div class="d-flex align-items-center">
+                                <h6 class="m-0">Move to:&nbsp;</h6>
+                                <select name="next_round" id="next_round" class="form-control w-50">
+                                @foreach($application->job->rounds as $round)
+                                    <option value="{{ $round->id }}">{{ $round->name }}</option>
+                                @endforeach
+                                </select>
+                                <button type="button" class="btn btn-success ml-2 round-submit" data-action="confirm">GO</button>
+                                @if ($applicantOpenApplications->count() > 1)
+                                    <button type="button" class="btn btn-outline-danger ml-2" data-toggle="modal" data-target="#application_reject_modal">Reject</button>
+                                @else
+                                    <button type="button" class="btn btn-outline-danger ml-2 round-submit" data-action="reject">Reject</button>
+                                @endif
+                            </div>
+                            @if ($applicantOpenApplications->count() > 1)
+                                @include('hr.application.rejection-modal', ['currentApplication' => $application, 'allApplications' => $applicantOpenApplications ])
+                            @endif
                         </div>
                         @elseif ($applicationRound->round_status === config('constants.hr.status.rejected.label') || !$applicationRound->mail_sent)
                         <div class="card-footer">
                             @if ($applicationRound->round_status === config('constants.hr.status.rejected.label'))
-                                <applicant-round-action-component
-                                :rounds="{{ json_encode($application->job->first()->rounds) }}">
-                                </applicant-round-action-component>
+                                <div class="d-inline-flex align-items-center w-75">
+                                    <h6 class="m-0">Move to:&nbsp;</h6>
+                                    <select name="next_round" id="next_round" class="form-control w-50">
+                                    @foreach($application->job->rounds as $round)
+                                        <option value="{{ $round->id }}">{{ $round->name }}</option>
+                                    @endforeach
+                                    </select>
+                                    <button type="button" class="btn btn-success ml-2 round-submit" data-action="confirm">GO</button>
+                                </div>
                             @endif
                             @if (!$applicationRound->mail_sent)
                                 <button type="button" class="btn btn-primary float-right" data-toggle="modal" data-target="#round_{{ $applicationRound->id }}">Send mail</button>
@@ -135,9 +154,7 @@
                         </div>
                         @endif
                     </div>
-                    <input type="hidden" name="round_status" value="{{ $applicationRound->round_status }}">
-                    <input type="hidden" name="next_round" value="0">
-                    <input type="hidden" name="action_type" value="new">
+                    <input type="hidden" name="action" value="updated">
                 </form>
                 @include('hr.round-guide-modal', ['round' => $applicationRound->round])
                 @includeWhen($applicationRound->round_status && !$applicationRound->mail_sent, 'hr.round-review-mail-modal', ['applicantRound' => $applicationRound])

--- a/resources/views/hr/application/index.blade.php
+++ b/resources/views/hr/application/index.blade.php
@@ -12,7 +12,7 @@
             <a class="nav-item nav-link {{ $status ? 'text-info' : 'active bg-info text-white' }}" href="/hr/applications"><i class="fa fa-clipboard"></i>&nbsp;Active</a>
         </li>
         <li class="nav-item">
-            <a class="nav-item nav-link {{ $status === config('constants.hr.status.rejected.label') ? 'active bg-info text-white' : 'text-info' }}" href="/hr/applications?status=rejected"><i class="fa fa-times-circle"></i>&nbsp;Rejected</a>
+            <a class="nav-item nav-link {{ $status === config('constants.hr.status.rejected.label') ? 'active bg-info text-white' : 'text-info' }}" href="/hr/applications?status={{ config('constants.hr.status.rejected.label') }}"><i class="fa fa-times-circle"></i>&nbsp;Rejected</a>
         </li>
     </ul>
     <table class="table table-striped table-bordered" id="applicants_table">

--- a/resources/views/hr/application/index.blade.php
+++ b/resources/views/hr/application/index.blade.php
@@ -12,7 +12,7 @@
             <a class="nav-item nav-link {{ $status ? 'text-info' : 'active bg-info text-white' }}" href="/hr/applications"><i class="fa fa-clipboard"></i>&nbsp;Active</a>
         </li>
         <li class="nav-item">
-            <a class="nav-item nav-link {{ $status === 'rejected' ? 'active bg-info text-white' : 'text-info' }}" href="/hr/applications?status=rejected"><i class="fa fa-times-circle"></i>&nbsp;Rejected</a>
+            <a class="nav-item nav-link {{ $status === config('constants.hr.status.rejected.label') ? 'active bg-info text-white' : 'text-info' }}" href="/hr/applications?status=rejected"><i class="fa fa-times-circle"></i>&nbsp;Rejected</a>
         </li>
     </ul>
     <table class="table table-striped table-bordered" id="applicants_table">

--- a/resources/views/hr/application/index.blade.php
+++ b/resources/views/hr/application/index.blade.php
@@ -6,6 +6,15 @@
     @include('hr.menu', ['active' => 'applications'])
     <br><br>
     <h1>Applications</h1>
+    <br>
+    <ul class="nav nav-pills mb-2">
+        <li class="nav-item">
+            <a class="nav-item nav-link {{ $status ? 'text-info' : 'active bg-info text-white' }}" href="/hr/applications"><i class="fa fa-clipboard"></i>&nbsp;Active</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-item nav-link {{ $status === 'rejected' ? 'active bg-info text-white' : 'text-info' }}" href="/hr/applications?status=rejected"><i class="fa fa-times-circle"></i>&nbsp;Rejected</a>
+        </li>
+    </ul>
     <table class="table table-striped table-bordered" id="applicants_table">
         <tr>
             <th>Name</th>

--- a/resources/views/hr/application/rejection-modal.blade.php
+++ b/resources/views/hr/application/rejection-modal.blade.php
@@ -1,0 +1,29 @@
+<div class="modal fade hr_round_review" id="application_reject_modal" tabindex="-1" role="dialog" aria-labelledby="application_reject_modal" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Select action</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+            	<div class="d-flex align-items-center">
+                	<span>Refer this candidate for&nbsp;&nbsp;</span>
+            		<select name="refer_to" id="refer_to" class="form-control w-50">
+                    @foreach($allApplications as $application)
+                        @if ($application->id != $currentApplication->id)
+                            <option value="{{ $application->id }}">{{ $application->job->title }}</option>
+                        @endif
+                    @endforeach
+            		</select>
+            		<button class="btn btn-primary ml-2 px-4 round-submit" data-action="refer">GO</button>
+                </div>
+                <h3 class="my-4 pl-1">OR</h3>
+                <div class="d-flex align-items-center">
+                    <button type="button" class="btn btn-outline-danger round-submit" data-action="reject">Reject this candidate for all jobs</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
#204 

Changes include:

1. Migration for deleting old columns `hr_applicant_id` from tables. After changes implemented in #210. These columns were needed to migrate data only and are no longer required.
2. Check for an applicant if it already exists.
3. Modified the workflow around applicant and application generation.
4. Modified the workflow around application round actions.
5. In case an applicant applies for multiple jobs, the first job is marked as in-progress. All the following will be marked as on-hold.
6. In case an applicant applies for multiple jobs, the reject action will open up a modal. That modal will have options either to reject for this application but refer for another appliction or to reject for all applications at once.