### PR TITLE
(#221) showing applicant timeline

### DIFF
--- a/app/Http/Controllers/HR/ApplicationController.php
+++ b/app/Http/Controllers/HR/ApplicationController.php
@@ -79,12 +79,14 @@ class ApplicationController extends Controller
     public function edit(Application $application)
     {
         $application->load(['job.rounds', 'applicant', 'applicant.applications', 'applicationRounds', 'applicationRounds.round']);
+        $applicant = $application->applicant;
 
         return view('hr.application.edit')->with([
-            'applicant' => $application->applicant,
+            'applicant' => $applicant,
             'application' => $application,
             'rounds' => Round::all(),
-            'applicantOpenApplications' => $application->applicant->openApplications(),
+            'applicantOpenApplications' => $applicant->openApplications(),
+            'timeline' => $applicant->timeline(),
         ]);
     }
 

--- a/app/Http/Controllers/HR/ApplicationController.php
+++ b/app/Http/Controllers/HR/ApplicationController.php
@@ -79,14 +79,13 @@ class ApplicationController extends Controller
     public function edit(Application $application)
     {
         $application->load(['job.rounds', 'applicant', 'applicant.applications', 'applicationRounds', 'applicationRounds.round']);
-        $applicant = $application->applicant;
 
         return view('hr.application.edit')->with([
-            'applicant' => $applicant,
+            'applicant' => $application->applicant,
             'application' => $application,
             'rounds' => Round::all(),
-            'applicantOpenApplications' => $applicant->openApplications(),
-            'timeline' => $applicant->timeline(),
+            'applicantOpenApplications' => $application->applicant->openApplications(),
+            'timeline' => $application->applicant->timeline(),
         ]);
     }
 

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -55,4 +55,30 @@ class Applicant extends Model
     {
         return $this->hasMany(Application::class, 'hr_applicant_id');
     }
+
+    public function timeline()
+    {
+        $timeline = [];
+        foreach ($this->applications as $application) {
+            $timeline[] = [
+                'type' => 'application-created',
+                'application' => $application,
+                'date' => $application->created_at,
+            ];
+            foreach ($application->applicationRounds as $applicationRound) {
+                if ($applicationRound->conducted_date) {
+                    $timeline[] = [
+                        'type' => 'round-conducted',
+                        'applicationRound' => $applicationRound,
+                        'date' => $applicationRound->conducted_date,
+                    ];
+                }
+            }
+        }
+        // sorting timeline based on date of each subarray in the timeline
+        array_multisort(array_map(function ($element) {
+            return $element['date'];
+        }, $timeline), SORT_ASC, $timeline);
+        return $timeline;
+    }
 }

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -62,6 +62,7 @@ class Applicant extends Model
      */
     public function timeline()
     {
+        $this->load('applications', 'applications.applicationRounds');
         $timeline = [];
         foreach ($this->applications as $application) {
             $timeline[] = [

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -58,11 +58,12 @@ class Applicant extends Model
 
     /**
      * Get the timeline for an applicant
+     *
      * @return array
      */
     public function timeline()
     {
-        $this->load('applications', 'applications.applicationRounds');
+        $this->load('applications');
         $timeline = [];
         foreach ($this->applications as $application) {
             $timeline[] = [
@@ -70,15 +71,7 @@ class Applicant extends Model
                 'application' => $application,
                 'date' => $application->created_at,
             ];
-            foreach ($application->applicationRounds as $applicationRound) {
-                if ($applicationRound->conducted_date) {
-                    $timeline[] = [
-                        'type' => 'round-conducted',
-                        'applicationRound' => $applicationRound,
-                        'date' => $applicationRound->conducted_date,
-                    ];
-                }
-            }
+            $timeline = array_merge($timeline, $application->timeline());
         }
         // Sort the timeline based on the date value in each subarray in the timeline.
         array_multisort(array_map(function ($element) {

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -56,6 +56,10 @@ class Applicant extends Model
         return $this->hasMany(Application::class, 'hr_applicant_id');
     }
 
+    /**
+     * Get the timeline for an applicant
+     * @return array
+     */
     public function timeline()
     {
         $timeline = [];
@@ -75,7 +79,7 @@ class Applicant extends Model
                 }
             }
         }
-        // sorting timeline based on date of each subarray in the timeline
+        // Sort the timeline based on the date value in each subarray in the timeline.
         array_multisort(array_map(function ($element) {
             return $element['date'];
         }, $timeline), SORT_ASC, $timeline);

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -98,12 +98,13 @@ class Application extends Model
      */
     public function timeline()
     {
-        $this->load('applicationRounds');
+        $this->load('applicationRounds', 'applicationRounds.round');
         $timeline = [];
         foreach ($this->applicationRounds as $applicationRound) {
             if ($applicationRound->conducted_date) {
                 $timeline[] = [
                     'type' => 'round-conducted',
+                    'application' => $this,
                     'applicationRound' => $applicationRound,
                     'date' => $applicationRound->conducted_date,
                 ];

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -90,4 +90,25 @@ class Application extends Model
     {
         return $this->hasMany(ApplicationRound::class, 'hr_application_id');
     }
+
+    /**
+     * Get the timeline for an application
+     *
+     * @return array
+     */
+    public function timeline()
+    {
+        $this->load('applicationRounds');
+        $timeline = [];
+        foreach ($this->applicationRounds as $applicationRound) {
+            if ($applicationRound->conducted_date) {
+                $timeline[] = [
+                    'type' => 'round-conducted',
+                    'applicationRound' => $applicationRound,
+                    'date' => $applicationRound->conducted_date,
+                ];
+            }
+        }
+        return $timeline;
+    }
 }

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -169,8 +169,8 @@
                                     <button type="button" class="btn btn-primary ml-auto" data-toggle="modal" data-target="#round_{{ $applicationRound->id }}">Send mail</button>
                                 @endif
                             </div>
+                            @endif
                         </div>
-                        @endif
                     </div>
                     <input type="hidden" name="action" value="updated">
                 </form>

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -70,7 +70,7 @@
                         </div>
                         <div class="form-group col-md-12">
                             <b>Reason for eligibility</b>
-                            <div>{{ $applicant->reason_for_eligibility ?? '-' }}</div>
+                            <div>{{ $application->reason_for_eligibility ?? '-' }}</div>
                         </div>
                     </div>
                 </div>

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -15,7 +15,7 @@
             @include('status', ['errors' => $errors->all()])
         </div>
         <div class="col-md-3">
-            @include('hr.application.timeline', ['applicant' => $applicant, 'application' => $application])
+            @include('hr.application.timeline', ['timeline' => $timeline])
         </div>
         <div class="col-md-7">
             <div class="card">
@@ -57,8 +57,8 @@
                         <div class="form-group col-md-5">
                             <b>Resume</b>
                             <div>
-                            @if ($applicant->resume)
-                                <a href="{{ $applicant->resume }}" target="_blank"><i class="fa fa-file fa-2x"></i></a>
+                            @if ($application->resume)
+                                <a href="{{ $application->resume }}" target="_blank"><i class="fa fa-file fa-2x"></i></a>
                             @else
                                 –
                             @endif

--- a/resources/views/hr/application/timeline.blade.php
+++ b/resources/views/hr/application/timeline.blade.php
@@ -17,9 +17,10 @@
                     @case('round-conducted')
                         @php
                             $applicationRound = $item['applicationRound'];
+                            $application = $item['application'];
                         @endphp
                         <b><u>{{ date(config('constants.display_date_format'), strtotime($applicationRound->conducted_date)) }}</u></b><br>
-                        {{ $applicationRound->round->name }} for {{ $applicationRound->application->job->title }} conducted by {{ $applicationRound->conductedPerson->name }}<br>
+                        {{ $applicationRound->round->name }} for {{ $application->job->title }} conducted by {{ $applicationRound->conductedPerson->name }}<br>
                         @if ($applicationRound->mail_sent)
                             <span data-toggle="modal" data-target="#round_mail_{{ $applicationRound->id }}" class="{{ config("constants.hr.status.$applicationRound->round_status.class") }} modal-toggler">Communication mail</span><br>
                             @include('hr.round-review-sent-mail-modal', [ 'applicationRound' => $applicationRound ])

--- a/resources/views/hr/application/timeline.blade.php
+++ b/resources/views/hr/application/timeline.blade.php
@@ -1,36 +1,32 @@
 <div class="timeline mb-5">
-    <div class="timeline-container">
-        <div class="content">
-            <b><u>{{ date(config('constants.display_date_format'), strtotime($applicant->created_at)) }}</u></b><br>
-            Applied for
-            @foreach($applicant->applications as $application)
-                <div>{{ $application->job->title }}</div>
-            @endforeach
-            @if ($application->autoresponder_subject && $application->autoresponder_body)
-                <span data-toggle="modal" data-target="#autoresponder_mail" class="modal-toggler-text text-primary">Auto-respond mail for system</span>
-                @include('hr.application.auto-respond', ['applicant' => $applicant, 'application' => $application])
-            @endif
+    @foreach ($timeline as $item)
+        <div class="timeline-container">
+            <div class="content">
+                @switch($item['type'])
+                    @case('application-created')
+                        @php
+                            $application = $item['application'];
+                        @endphp
+                        <b><u>{{ date(config('constants.display_date_format'), strtotime($application->created_at)) }}</u></b><br>
+                        <div>Applied for {{ $application->job->title }}</div>
+                        @if ($application->autoresponder_subject && $application->autoresponder_body)
+                            <span data-toggle="modal" data-target="#autoresponder_mail" class="modal-toggler-text text-primary">Auto-respond mail for system</span>
+                            @include('hr.application.auto-respond', ['applicant' => $application->applicant, 'application' => $application])
+                        @endif
+                        @break
+                    @case('round-conducted')
+                        @php
+                            $applicationRound = $item['applicationRound'];
+                        @endphp
+                        <b><u>{{ date(config('constants.display_date_format'), strtotime($applicationRound->conducted_date)) }}</u></b><br>
+                        {{ $applicationRound->round->name }} conducted by {{ $applicationRound->conductedPerson->name }}<br>
+                        @if ($applicationRound->mail_sent)
+                            <span data-toggle="modal" data-target="#round_mail_{{ $applicationRound->id }}" class="{{ config("constants.hr.status.$applicationRound->round_status.class") }} modal-toggler">Communication mail</span><br>
+                            @include('hr.round-review-sent-mail-modal', [ 'applicationRound' => $applicationRound ])
+                        @endif
+                        @break
+                @endswitch
+            </div>
         </div>
-    </div>
-    @foreach ($application->applicationRounds as $applicationRound)
-        @if ($applicationRound->scheduled_date)
-            <div class="timeline-container">
-                <div class="content">
-                    {{ $applicationRound->round->name }} scheduled on {{ date(config('constants.display_date_format'), strtotime($applicationRound->scheduled_date)) }}
-                </div>
-            </div>
-        @endif
-        @if ($applicationRound->conducted_date)
-            <div class="timeline-container">
-                <div class="content">
-                    <b><u>{{ date(config('constants.display_date_format'), strtotime($applicationRound->conducted_date)) }}</u></b><br>
-                    {{ $applicationRound->round->name }} conducted by {{ $applicationRound->conductedPerson->name }}<br>
-                    @if ($applicationRound->mail_sent)
-                        <span data-toggle="modal" data-target="#round_mail_{{ $applicationRound->id }}" class="{{ config("constants.hr.status.$applicationRound->round_status.class") }} modal-toggler">Communication mail</span><br>
-                        @include('hr.round-review-sent-mail-modal', [ 'applicationRound' => $applicationRound ])
-                    @endif
-                </div>
-            </div>
-        @endif
     @endforeach
 </div>

--- a/resources/views/hr/application/timeline.blade.php
+++ b/resources/views/hr/application/timeline.blade.php
@@ -10,7 +10,7 @@
                         <b><u>{{ date(config('constants.display_date_format'), strtotime($application->created_at)) }}</u></b><br>
                         <div>Applied for {{ $application->job->title }}</div>
                         @if ($application->autoresponder_subject && $application->autoresponder_body)
-                            <span data-toggle="modal" data-target="#autoresponder_mail" class="modal-toggler-text text-primary">Auto-respond mail for system</span>
+                            <span data-toggle="modal" data-target="#autoresponder_mail" class="modal-toggler-text text-primary">Auto-respond mail from system</span>
                             @include('hr.application.auto-respond', ['applicant' => $application->applicant, 'application' => $application])
                         @endif
                         @break
@@ -19,7 +19,7 @@
                             $applicationRound = $item['applicationRound'];
                         @endphp
                         <b><u>{{ date(config('constants.display_date_format'), strtotime($applicationRound->conducted_date)) }}</u></b><br>
-                        {{ $applicationRound->round->name }} conducted by {{ $applicationRound->conductedPerson->name }}<br>
+                        {{ $applicationRound->round->name }} for {{ $applicationRound->application->job->title }} conducted by {{ $applicationRound->conductedPerson->name }}<br>
                         @if ($applicationRound->mail_sent)
                             <span data-toggle="modal" data-target="#round_mail_{{ $applicationRound->id }}" class="{{ config("constants.hr.status.$applicationRound->round_status.class") }} modal-toggler">Communication mail</span><br>
                             @include('hr.round-review-sent-mail-modal', [ 'applicationRound' => $applicationRound ])


### PR DESCRIPTION
#221 

Changes include:

1. Getting applicant timeline and with all `applications` and `applicationRound` details. Sorting the timeline based on the order of date for each event.
2. Resume icon and reason for eligibility was not showing up in the application edit screen. Fixed.