### PR TITLE
(#61) Sending notification to the scheduled user

### DIFF
--- a/app/Models/HR/ApplicationRound.php
+++ b/app/Models/HR/ApplicationRound.php
@@ -9,6 +9,7 @@ use App\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use App\Notifications\HR\ApplicationRoundScheduled;
 
 class ApplicationRound extends Model
 {
@@ -38,13 +39,14 @@ class ApplicationRound extends Model
                 $fillable['round_status'] = 'confirmed';
                 $application->markInProgress();
                 $nextApplicationRound = $application->job->rounds->where('id', $attr['next_round'])->first();
-                $scheduledPersonId = $nextApplicationRound->pivot->hr_round_interviewer_id;
+                $scheduledPersonId = $nextApplicationRound->pivot->hr_round_interviewer_id ?? config('constants.hr.defaults.scheduled_person_id');
                 $applicationRound = self::_create([
                     'hr_application_id' => $application->id,
                     'hr_round_id' => $attr['next_round'],
                     'scheduled_date' => Carbon::now()->addDay(),
-                    'scheduled_person_id' => $scheduledPersonId ?? config('constants.hr.defaults.scheduled_person_id'),
+                    'scheduled_person_id' => $scheduledPersonId,
                 ]);
+                User::find($scheduledPersonId)->notify(new ApplicationRoundScheduled($applicationRound));
                 break;
 
             case 'reject':
@@ -62,6 +64,7 @@ class ApplicationRound extends Model
         }
         $this->update($fillable);
         $this->_updateOrCreateReviews($attr['reviews']);
+
     }
 
     protected function _updateOrCreateReviews($reviews = [])

--- a/app/Notifications/HR/ApplicationRoundScheduled.php
+++ b/app/Notifications/HR/ApplicationRoundScheduled.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Notifications\HR;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use App\Models\HR\ApplicationRound;
+
+class ApplicationRoundScheduled extends Notification
+{
+    use Queueable;
+
+    /**
+     * The application round that has been scheduled.
+     */
+    protected $applicationRound;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @param ApplicationRound $applicationRound
+     */
+    public function __construct(ApplicationRound $applicationRound)
+    {
+        $this->applicationRound = $applicationRound;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $application = $this->applicationRound->application;
+        return (new MailMessage)
+                    ->subject( config('app.name') . ': New application round scheduled')
+                    ->line('You have been assigned to conduct an application round.')
+                    ->action('View this application', url("hr/applications/$application->id/edit"));
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'name' => env('APP_NAME', 'Laravel'),
+    'name' => env('APP_NAME', 'Employee Portal'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
#61 

Changes include:

1. Using Laravel's default notification to send mail to interviewer set for the new round. This is only triggered if an application round is marked as confirmed.