### PR TITLE
(#257) schedule next round

### DIFF
--- a/app/Http/Requests/HR/ApplicationRoundRequest.php
+++ b/app/Http/Requests/HR/ApplicationRoundRequest.php
@@ -26,10 +26,12 @@ class ApplicationRoundRequest extends FormRequest
         return [
             'reviews' => 'nullable',
             'action' => 'required|string',
-            'next_round' => 'nullable|string|required_if:action,confirm',
             'refer_to' => 'nullable|string|required_if:action,refer',
             'scheduled_date' => 'nullable|date|required_if:action,schedule-update',
             'scheduled_person_id' => 'nullable|integer|required_if:action,schedule-update',
+            'next_round' => 'nullable|string|required_if:action,confirm',
+            'next_scheduled_date' => 'nullable|date|required_if:action,confirm',
+            'next_scheduled_person_id' => 'nullable|integer|required_if:action,confirm',
         ];
     }
 }

--- a/app/Models/HR/ApplicationRound.php
+++ b/app/Models/HR/ApplicationRound.php
@@ -50,8 +50,8 @@ class ApplicationRound extends Model
                 $applicationRound = self::_create([
                     'hr_application_id' => $application->id,
                     'hr_round_id' => $attr['next_round'],
-                    'scheduled_date' => Carbon::now()->addDay(),
-                    'scheduled_person_id' => $scheduledPersonId ?? config('constants.hr.defaults.scheduled_person_id'),
+                    'scheduled_date' => $attr['next_scheduled_date'],
+                    'scheduled_person_id' => $attr['next_scheduled_person_id'],
                 ]);
                 break;
 

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -26,7 +26,27 @@ Vue.component('applicant-round-action-component', require('./components/HR/Appli
 
 if (document.getElementById('page_hr_applicant_edit')) {
     const applicantEdit = new Vue({
-        el: '#page_hr_applicant_edit'
+        el: '#page_hr_applicant_edit',
+        data: {
+            applicationJobRounds: JSON.parse(document.getElementById('next_round').dataset.applicationJobRounds) || {},
+            selectedNextRound: '',
+            nextRoundName: '',
+        },
+        methods: {
+            updateNextRoundName: function() {
+                for (let index = 0; index < this.applicationJobRounds.length; index++) {
+                    let applicationRound = this.applicationJobRounds[index];
+                    if (applicationRound.id == this.selectedNextRound) {
+                        this.nextRoundName = applicationRound.name;
+                        break;
+                    }
+                }
+            }
+        },
+        mounted() {
+            this.selectedNextRound = this.applicationJobRounds[0].id;
+            this.nextRoundName = this.applicationJobRounds[0].name;
+        }
     });
 }
 

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -166,7 +166,7 @@
                                         <option value="{{ $round->id }}">{{ $round->name }}</option>
                                     @endforeach
                                     </select>
-                                    <button type="button" class="btn btn-success ml-2 round-submit" data-action="confirm">GO</button>
+                                    <button type="button" class="btn btn-success ml-2" data-toggle="modal" data-target="#round_confirm_{{ $applicationRound->id }}">Confirm</button>
                                     @if ($applicantOpenApplications->count() > 1)
                                         <button type="button" class="btn btn-outline-danger ml-2" data-toggle="modal" data-target="#application_reject_modal">Reject</button>
                                     @else
@@ -187,7 +187,7 @@
                                             <option value="{{ $round->id }}">{{ $round->name }}</option>
                                         @endforeach
                                         </select>
-                                        <button type="button" class="btn btn-success ml-2 round-submit" data-action="confirm">GO</button>
+                                        <button type="button" class="btn btn-success ml-2 round-submit" data-action="confirm">Confirm</button>
                                     </div>
                                 @endif
                                 @if (!$applicationRound->mail_sent)
@@ -198,6 +198,7 @@
                         </div>
                     </div>
                     <input type="hidden" name="action" value="updated">
+                    @includeWhen($applicationRound->round_status != 'confirmed', 'hr.round-review-confirm-modal', ['applicationRound' => $applicationRound])
                 </form>
                 @include('hr.round-guide-modal', ['round' => $applicationRound->round])
                 @includeWhen($applicationRound->round_status && !$applicationRound->mail_sent, 'hr.round-review-mail-modal', ['applicantRound' => $applicationRound])

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -161,10 +161,8 @@
                             <div class="card-footer">
                                 <div class="d-flex align-items-center">
                                     <h6 class="m-0">Move to:&nbsp;</h6>
-                                    <select name="next_round" id="next_round" class="form-control w-50">
-                                    @foreach($application->job->rounds as $round)
-                                        <option value="{{ $round->id }}">{{ $round->name }}</option>
-                                    @endforeach
+                                    <select name="next_round" id="next_round" class="form-control w-50" v-model="selectedNextRound" @change="updateNextRoundName" data-application-job-rounds="{{ json_encode($application->job->rounds) }}">
+                                        <option v-for="round in applicationJobRounds" :value="round.id" v-text="round.name"></option>
                                     </select>
                                     <button type="button" class="btn btn-success ml-2" data-toggle="modal" data-target="#round_confirm_{{ $applicationRound->id }}">Confirm</button>
                                     @if ($applicantOpenApplications->count() > 1)
@@ -182,12 +180,10 @@
                                 @if ($applicationRound->round_status === config('constants.hr.status.rejected.label'))
                                     <div class="d-inline-flex align-items-center w-75">
                                         <h6 class="m-0">Move to:&nbsp;</h6>
-                                        <select name="next_round" id="next_round" class="form-control w-50">
-                                        @foreach($application->job->rounds as $round)
-                                            <option value="{{ $round->id }}">{{ $round->name }}</option>
-                                        @endforeach
+                                        <select name="next_round" id="next_round" class="form-control w-50" v-model="selectedNextRound" @change="updateNextRoundName" data-application-job-rounds="{{ json_encode($application->job->rounds) }}">
+                                            <option v-for="round in applicationJobRounds" :value="round.id" v-text="round.name"></option>
                                         </select>
-                                        <button type="button" class="btn btn-success ml-2 round-submit" data-action="confirm">Confirm</button>
+                                        <button type="button" class="btn btn-success ml-2" data-toggle="modal" data-target="#round_confirm_{{ $applicationRound->id }}">Confirm</button>
                                     </div>
                                 @endif
                                 @if (!$applicationRound->mail_sent)

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -198,7 +198,7 @@
                         </div>
                     </div>
                     <input type="hidden" name="action" value="updated">
-                    @includeWhen($applicationRound->round_status != 'confirmed', 'hr.round-review-confirm-modal', ['applicationRound' => $applicationRound])
+                    @includeWhen($applicationRound->round_status != config('constants.hr.status.confirmed.label'), 'hr.round-review-confirm-modal', ['applicationRound' => $applicationRound])
                 </form>
                 @include('hr.round-guide-modal', ['round' => $applicationRound->round])
                 @includeWhen($applicationRound->round_status && !$applicationRound->mail_sent, 'hr.round-review-mail-modal', ['applicantRound' => $applicationRound])

--- a/resources/views/hr/round-review-confirm-modal.blade.php
+++ b/resources/views/hr/round-review-confirm-modal.blade.php
@@ -1,39 +1,33 @@
 <div class="modal fade hr_round_guide" id="round_confirm_{{ $applicationRound->id }}" tabindex="-1" role="dialog" aria-labelledby="round_confirm_{{ $applicationRound->id }}" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
-            <form action="/hr/rounds/{{ $applicationRound->id }}" method="POST">
-
-                {{ csrf_field() }}
-                {{ method_field('PATCH') }}
-
-                <div class="modal-header">
+            <div class="modal-header">
                 <h5 class="modal-title" id="round_confirm_{{ $applicationRound->id }}">Schedule @{{ nextRoundName }}</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <div class="form-row">
-                        <div class="form-group col-md-5">
-                            <label for="next_scheduled_date">Scheduled date</label>
-                            <input type="datetime-local" name="next_scheduled_date" id="next_scheduled_date" class="form-control">
-                        </div>
-                        <div class="form-group offset-md-1 col-md-5">
-                            <label for="next_scheduled_person_id">Scheduled for</label>
-                            <select name="next_scheduled_person_id" id="next_scheduled_person_id" class="form-control">
-                                @foreach ($interviewers as $interviewer)
-                                    <option value="{{ $interviewer->id }}">{{ $interviewer->name }}</option>
-                                @endforeach
-                            </select>
-                        </div>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="form-row">
+                    <div class="form-group col-md-5">
+                        <label for="next_scheduled_date">Scheduled date</label>
+                        <input type="datetime-local" name="next_scheduled_date" id="next_scheduled_date" class="form-control">
                     </div>
-                    <div class="form-row mt-2">
-                        <div class="form-group col-md-11">
-                            <button type="button" class="btn btn-success px-4 round-submit" data-action="confirm">Confirm</button>
-                        </div>
+                    <div class="form-group offset-md-1 col-md-5">
+                        <label for="next_scheduled_person_id">Scheduled for</label>
+                        <select name="next_scheduled_person_id" id="next_scheduled_person_id" class="form-control">
+                            @foreach ($interviewers as $interviewer)
+                                <option value="{{ $interviewer->id }}">{{ $interviewer->name }}</option>
+                            @endforeach
+                        </select>
                     </div>
                 </div>
-            </form>
+                <div class="form-row mt-2">
+                    <div class="form-group col-md-12">
+                        <button type="button" class="btn btn-success px-4 round-submit" data-action="confirm">Confirm</button>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/resources/views/hr/round-review-confirm-modal.blade.php
+++ b/resources/views/hr/round-review-confirm-modal.blade.php
@@ -7,7 +7,7 @@
                 {{ method_field('PATCH') }}
 
                 <div class="modal-header">
-                <h5 class="modal-title" id="round_confirm_{{ $applicationRound->id }}">Schedule next round</h5>
+                <h5 class="modal-title" id="round_confirm_{{ $applicationRound->id }}">Schedule @{{ nextRoundName }}</h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>

--- a/resources/views/hr/round-review-confirm-modal.blade.php
+++ b/resources/views/hr/round-review-confirm-modal.blade.php
@@ -1,4 +1,4 @@
-<div class="modal fade hr_round_guide" id="round_confirm_{{ $applicationRound->id }}" tabindex="-1" role="dialog" aria-labelledby="round_confirm_{{ $applicationRound->id }}" aria-hidden="true">
+<div class="modal fade" id="round_confirm_{{ $applicationRound->id }}" tabindex="-1" role="dialog" aria-labelledby="round_confirm_{{ $applicationRound->id }}" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">

--- a/resources/views/hr/round-review-confirm-modal.blade.php
+++ b/resources/views/hr/round-review-confirm-modal.blade.php
@@ -1,0 +1,39 @@
+<div class="modal fade hr_round_guide" id="round_confirm_{{ $applicationRound->id }}" tabindex="-1" role="dialog" aria-labelledby="round_confirm_{{ $applicationRound->id }}" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <form action="/hr/rounds/{{ $applicationRound->id }}" method="POST">
+
+                {{ csrf_field() }}
+                {{ method_field('PATCH') }}
+
+                <div class="modal-header">
+                <h5 class="modal-title" id="round_confirm_{{ $applicationRound->id }}">Schedule next round</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-row">
+                        <div class="form-group col-md-5">
+                            <label for="next_scheduled_date">Scheduled date</label>
+                            <input type="datetime-local" name="next_scheduled_date" id="next_scheduled_date" class="form-control">
+                        </div>
+                        <div class="form-group offset-md-1 col-md-5">
+                            <label for="next_scheduled_person_id">Scheduled for</label>
+                            <select name="next_scheduled_person_id" id="next_scheduled_person_id" class="form-control">
+                                @foreach ($interviewers as $interviewer)
+                                    <option value="{{ $interviewer->id }}">{{ $interviewer->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-row mt-2">
+                        <div class="form-group col-md-11">
+                            <button type="button" class="btn btn-success px-4 round-submit" data-action="confirm">Confirm</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
#257 

Changes include:

1. Showing a modal which asks for `next_scheduled_date` and `next_scheduled_person_id`
2. Changed text of "GO" button to "Confirm"
3. Saving submitted schedule date and interviewer for next round the action type is confirmed.