### PR TITLE
(#263) recovering round feedback

### DIFF
--- a/app/Http/Requests/HR/ApplicationRoundRequest.php
+++ b/app/Http/Requests/HR/ApplicationRoundRequest.php
@@ -34,4 +34,17 @@ class ApplicationRoundRequest extends FormRequest
             'next_scheduled_person_id' => 'nullable|integer|required_if:action,confirm',
         ];
     }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'next_scheduled_date.required_if' => 'The schedule date for next round is required.',
+            'next_scheduled_person_id.required_if' => 'The interviewer for next round is required.',
+        ];
+    }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -168,6 +168,10 @@ if (document.getElementById('finance_report')) {
 
 $('#page_hr_applicant_edit .applicant-round-form').on('click', '.round-submit', function(){
     var form = $(this).closest('.applicant-round-form');
+    if (!form[0].checkValidity()) {
+        form[0].reportValidity();
+        return false;
+    }
     form.find('[name="action"]').val($(this).data('action'));
     form.submit();
 });
@@ -389,7 +393,7 @@ if (document.getElementById('books_listing')) {
         },
 
         methods: {
-            updateCategoryMode : function(index, mode) { 
+            updateCategoryMode : function(index, mode) {
                 this.$set(this.books[index], 'showCategories', (mode === 'edit'));
             },
 

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -148,6 +148,11 @@
                                 <div class="form-row">
                                     <div class="form-group col-md-12">
                                         <label for="reviews[feedback]">Feedback</label>
+                                        @php
+                                            if ($loop->last && sizeOf($errors)) {
+                                                $applicationReviewValue = old('reviews.feedback');
+                                            }
+                                        @endphp
                                         <textarea name="reviews[feedback]" id="reviews[feedback]" rows="6" class="form-control">{{ $applicationReviewValue }}</textarea>
                                     </div>
                                 </div>

--- a/resources/views/hr/round-review-confirm-modal.blade.php
+++ b/resources/views/hr/round-review-confirm-modal.blade.php
@@ -11,11 +11,11 @@
                 <div class="form-row">
                     <div class="form-group col-md-5">
                         <label for="next_scheduled_date">Scheduled date</label>
-                        <input type="datetime-local" name="next_scheduled_date" id="next_scheduled_date" class="form-control">
+                        <input type="datetime-local" name="next_scheduled_date" id="next_scheduled_date" class="form-control" required="required">
                     </div>
                     <div class="form-group offset-md-1 col-md-5">
                         <label for="next_scheduled_person_id">Scheduled for</label>
-                        <select name="next_scheduled_person_id" id="next_scheduled_person_id" class="form-control">
+                        <select name="next_scheduled_person_id" id="next_scheduled_person_id" class="form-control" required="required">
                             @foreach ($interviewers as $interviewer)
                                 <option value="{{ $interviewer->id }}">{{ $interviewer->name }}</option>
                             @endforeach


### PR DESCRIPTION
#263 

Changes include:

1. Added front-end validation for `next_scheduled_date` and `next_scheduled_person_id`.
2. Added back-end validation messages for the above two fields.
3. In case the server side validation fails, the last round will show the `old('feedback')` value.