### PR TITLE
(#279) BCC to HR group

### DIFF
--- a/app/Http/Controllers/HR/ApplicationRoundController.php
+++ b/app/Http/Controllers/HR/ApplicationRoundController.php
@@ -40,9 +40,7 @@ class ApplicationRoundController extends Controller
         $validated = $request->validated();
         $mail_body = ContentHelper::editorFormat($validated['mail_body']);
 
-        $application = $applicationRound->application;
-        $applicant = $application->applicant;
-
+        $applicationRound->load('application', 'application.job', 'application.applicant');
         $applicationRound->update([
             'mail_sent' => true,
             'mail_subject' => $validated['mail_subject'],
@@ -51,10 +49,9 @@ class ApplicationRoundController extends Controller
             'mail_sent_at' => Carbon::now(),
         ]);
 
-        Mail::to($applicant->email, $applicant->name)
-            ->bcc($application->job->posted_by)
-            ->send(new RoundReviewed($applicationRound));
+        Mail::send(new RoundReviewed($applicationRound));
 
+        $applicant = $applicationRound->application->applicant;
         return redirect()->back()->with(
             'status',
             "Mail sent successfully to the <b>$applicant->name</b> at <b>$applicant->email</b>.<br>

--- a/app/Mail/HR/Applicant/RoundReviewed.php
+++ b/app/Mail/HR/Applicant/RoundReviewed.php
@@ -35,7 +35,12 @@ class RoundReviewed extends Mailable
      */
     public function build()
     {
-        return $this->from(env('HR_DEFAULT_FROM_EMAIL'), env('HR_DEFAULT_FROM_NAME'))
+        $application = $this->applicationRound->application;
+
+        return $this->to($application->applicant->email, $application->applicant->name)
+            ->bcc($application->job->posted_by)
+            ->bcc(env('HR_DEFAULT_FROM_EMAIL'))
+            ->from(env('HR_DEFAULT_FROM_EMAIL'), env('HR_DEFAULT_FROM_NAME'))
             ->subject($this->applicationRound->mail_subject)
             ->view('mail.plain')->with([
                 'body' => $this->applicationRound->mail_body


### PR DESCRIPTION
#279 

Changes include:

1. Sending RoundReviewed mail to the HR group as well along with the job creator. That means anyone who created job and is also a member of the HR group will receive the email twice.