### PR TITLE
(#285) round not conducted

### DIFF
--- a/app/Http/Controllers/HR/Applications/ApplicationController.php
+++ b/app/Http/Controllers/HR/Applications/ApplicationController.php
@@ -11,6 +11,7 @@ use App\Models\HR\Job;
 use App\Http\Requests\HR\ApplicationRequest;
 use Illuminate\Support\Facades\Mail;
 use App\Mail\HR\Application\JobChanged;
+use App\Models\HR\ApplicationMeta;
 
 abstract class ApplicationController extends Controller
 {
@@ -86,6 +87,20 @@ abstract class ApplicationController extends Controller
                 $changeJobMeta = $application->changeJob($validated);
                 Mail::send(new JobChanged($application, $changeJobMeta));
                 return redirect()->route('applications.internship.edit', $id)->with('status', 'Application updated successfully!');
+                break;
+            case 'round-not-conducted':
+                ApplicationMeta::create([
+                    'hr_application_id' => $application->id,
+                    'key' => 'round-not-conducted',
+                    'value' => json_encode([
+                        'application_round_id' => $validated['application_round_id'],
+                        'mail_subject' => $validated['round_not_conducted_mail_subject'],
+                        'mail_body' => $validated['round_not_conducted_mail_body'],
+                    ]),
+                ]);
+                return redirect()->back()->with('status', 'Application updated successfully!');
+                // send the mail
+                dd('here');
                 break;
         }
 

--- a/app/Http/Controllers/HR/Applications/ApplicationController.php
+++ b/app/Http/Controllers/HR/Applications/ApplicationController.php
@@ -14,6 +14,7 @@ use App\Mail\HR\Application\JobChanged;
 use App\Models\HR\ApplicationMeta;
 use App\Mail\HR\Application\RoundNotConducted;
 use Illuminate\Support\Facades\Auth;
+use App\Models\Setting;
 
 abstract class ApplicationController extends Controller
 {
@@ -62,6 +63,9 @@ abstract class ApplicationController extends Controller
             'interviewers' => User::interviewers()->get(),
             'applicantOpenApplications' => $application->applicant->openApplications(),
             'applicationFormDetails' => $application->applicationMeta()->formData()->first(),
+            'settings' => [
+                'roundNotConducted' => Setting::getRoundNotConductedEmail()
+            ]
         ];
 
         if ($application->job->type == 'job') {

--- a/app/Http/Controllers/HR/Applications/ApplicationController.php
+++ b/app/Http/Controllers/HR/Applications/ApplicationController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\HR\ApplicationRequest;
 use Illuminate\Support\Facades\Mail;
 use App\Mail\HR\Application\JobChanged;
 use App\Models\HR\ApplicationMeta;
+use App\Mail\HR\Application\RoundNotConducted;
 
 abstract class ApplicationController extends Controller
 {
@@ -89,18 +90,18 @@ abstract class ApplicationController extends Controller
                 return redirect()->route('applications.internship.edit', $id)->with('status', 'Application updated successfully!');
                 break;
             case 'round-not-conducted':
-                ApplicationMeta::create([
+                $roundNotConductedMeta = ApplicationMeta::create([
                     'hr_application_id' => $application->id,
                     'key' => 'round-not-conducted',
                     'value' => json_encode([
                         'application_round_id' => $validated['application_round_id'],
+                        'reason' => $validated['round_not_conducted_reason'],
                         'mail_subject' => $validated['round_not_conducted_mail_subject'],
                         'mail_body' => $validated['round_not_conducted_mail_body'],
                     ]),
                 ]);
+                Mail::send(new RoundNotConducted($application, $roundNotConductedMeta));
                 return redirect()->back()->with('status', 'Application updated successfully!');
-                // send the mail
-                dd('here');
                 break;
         }
 

--- a/app/Http/Controllers/HR/Applications/ApplicationController.php
+++ b/app/Http/Controllers/HR/Applications/ApplicationController.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Mail;
 use App\Mail\HR\Application\JobChanged;
 use App\Models\HR\ApplicationMeta;
 use App\Mail\HR\Application\RoundNotConducted;
+use Illuminate\Support\Facades\Auth;
 
 abstract class ApplicationController extends Controller
 {
@@ -89,13 +90,14 @@ abstract class ApplicationController extends Controller
                 Mail::send(new JobChanged($application, $changeJobMeta));
                 return redirect()->route('applications.internship.edit', $id)->with('status', 'Application updated successfully!');
                 break;
-            case 'round-not-conducted':
+            case config('constants.hr.application-meta.keys.round-not-conducted'):
                 $roundNotConductedMeta = ApplicationMeta::create([
                     'hr_application_id' => $application->id,
-                    'key' => 'round-not-conducted',
+                    'key' => $validated['action'],
                     'value' => json_encode([
-                        'application_round_id' => $validated['application_round_id'],
+                        'round' => $validated['application_round_id'],
                         'reason' => $validated['round_not_conducted_reason'],
+                        'user' => Auth::id(),
                         'mail_subject' => $validated['round_not_conducted_mail_subject'],
                         'mail_body' => $validated['round_not_conducted_mail_body'],
                     ]),

--- a/app/Http/Requests/HR/ApplicationRequest.php
+++ b/app/Http/Requests/HR/ApplicationRequest.php
@@ -28,10 +28,10 @@ class ApplicationRequest extends FormRequest
             'hr_job_id' => 'nullable|integer|required_if:action,' . config('constants.hr.application-meta.keys.change-job'),
             'job_change_mail_subject' => 'nullable|string|required_if:action,' . config('constants.hr.application-meta.keys.change-job'),
             'job_change_mail_body' => 'nullable|string|required_if:action,' . config('constants.hr.application-meta.keys.change-job'),
-            'application_round_id' => 'nullable|integer|required_if:action,round-not-conducted',
-            'round_not_conducted_reason' => 'nullable|string|required_if:action,round-not-conducted',
-            'round_not_conducted_mail_subject' => 'nullable|string|required_if:action,round-not-conducted',
-            'round_not_conducted_mail_body' => 'nullable|string|required_if:action,round-not-conducted',
+            'application_round_id' => 'nullable|integer|required_if:action,' . config('constants.hr.application-meta.keys.round-not-conducted'),
+            'round_not_conducted_reason' => 'nullable|string|required_if:action,' . config('constants.hr.application-meta.keys.round-not-conducted'),
+            'round_not_conducted_mail_subject' => 'nullable|string|required_if:action,' . config('constants.hr.application-meta.keys.round-not-conducted'),
+            'round_not_conducted_mail_body' => 'nullable|string|required_if:action,' . config('constants.hr.application-meta.keys.round-not-conducted'),
         ];
     }
 }

--- a/app/Http/Requests/HR/ApplicationRequest.php
+++ b/app/Http/Requests/HR/ApplicationRequest.php
@@ -28,6 +28,10 @@ class ApplicationRequest extends FormRequest
             'hr_job_id' => 'nullable|integer|required_if:action,' . config('constants.hr.application-meta.keys.change-job'),
             'job_change_mail_subject' => 'nullable|string|required_if:action,' . config('constants.hr.application-meta.keys.change-job'),
             'job_change_mail_body' => 'nullable|string|required_if:action,' . config('constants.hr.application-meta.keys.change-job'),
+            'application_round_id' => 'nullable|integer|required_if:action,round-not-conducted',
+            'round_not_conducted_reason' => 'nullable|string|required_if:action,round-not-conducted',
+            'round_not_conducted_mail_subject' => 'nullable|string|required_if:action,round-not-conducted',
+            'round_not_conducted_mail_body' => 'nullable|string|required_if:action,round-not-conducted',
         ];
     }
 }

--- a/app/Mail/HR/Application/RoundNotConducted.php
+++ b/app/Mail/HR/Application/RoundNotConducted.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Mail\HR\Application;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use App\Models\HR\ApplicationMeta;
+use App\Models\HR\Application;
+
+class RoundNotConducted extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Application instance for which round wasn't conducted
+     *
+     * @var Application
+     */
+    public $application;
+
+    /**
+     * Application meta that tracks the details due to which round wasn't conducted.
+     *
+     * @var ApplicationMeta
+     */
+    public $applicationMeta;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct(Application $application, ApplicationMeta $applicationMeta)
+    {
+        $this->application = $application;
+        $this->applicationMeta = json_decode($applicationMeta->value);
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->to($this->application->applicant->email, $this->application->applicant->name)
+            ->from(env('HR_DEFAULT_FROM_EMAIL'), env('HR_DEFAULT_FROM_NAME'))
+            ->subject($this->applicationMeta->mail_subject)
+            ->view('mail.plain')->with([
+                'body' => $this->applicationMeta->mail_body
+            ]);
+    }
+}

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -195,7 +195,7 @@ class Application extends Model
             $details->user = User::find($details->user)->name;
             $event->value = $details;
             $timeline[] = [
-                'type' => config('constants.hr.application-meta.keys.job-changed'),
+                'type' => config('constants.hr.application-meta.keys.change-job'),
                 'event'=> $event,
                 'date' => $event->created_at,
             ];

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -195,11 +195,26 @@ class Application extends Model
             $details->user = User::find($details->user)->name;
             $event->value = $details;
             $timeline[] = [
-                'type' => 'job-changed',
+                'type' => config('constants.hr.application-meta.keys.job-changed'),
                 'event'=> $event,
                 'date' => $event->created_at,
             ];
         }
+
+        // adding change-job events in the application timeline
+        $jobChangeEvents = $this->applicationMeta()->roundNotConducted()->get();
+        foreach ($jobChangeEvents as $event) {
+            $details = json_decode($event->value);
+            $details->round = ApplicationRound::find($details->round)->round->name;
+            $details->user = User::find($details->user)->name;
+            $event->value = $details;
+            $timeline[] = [
+                'type' => config('constants.hr.application-meta.keys.round-not-conducted'),
+                'event' => $event,
+                'date' => $event->created_at,
+            ];
+        }
+
         return $timeline;
     }
 

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -201,7 +201,7 @@ class Application extends Model
             ];
         }
 
-        // adding change-job events in the application timeline
+        // adding round-not-conducted events in the application timeline
         $jobChangeEvents = $this->applicationMeta()->roundNotConducted()->get();
         foreach ($jobChangeEvents as $event) {
             $details = json_decode($event->value);

--- a/app/Models/HR/ApplicationMeta.php
+++ b/app/Models/HR/ApplicationMeta.php
@@ -36,37 +36,33 @@ class ApplicationMeta extends Model
      *
      * @return mixed
      */
-    public function getJobChangedCommunicationMailAttribute()
+    public function getCommunicationMailAttribute()
     {
-        if ($this->key != config('constants.hr.application-meta.keys.change-job')) {
-            return false;
-        }
         $this->load('application', 'application.applicant');
 
-        return [
-            'modal-id' => 'job_change_' . $this->id,
+        $attr = [
             'mail-to' => $this->application->applicant->email,
-            'mail-subject' => $this->value->job_change_mail_subject,
-            'mail-body' => $this->value->job_change_mail_body,
             'mail-sender' => $this->value->user,
             'mail-date' => $this->created_at,
         ];
-    }
 
-    public function getRoundNotConductedCommunicationMailAttribute()
-    {
-        if ($this->key != config('constants.hr.application-meta.keys.round-not-conducted')) {
-            return false;
+        switch ($this->key) {
+            case config('constants.hr.application-meta.keys.change-job') :
+                $attr['modal-id'] = 'job_change_' . $this->id;
+                $attr['mail-subject'] = $this->value->job_change_mail_subject;
+                $attr['mail-body'] = $this->value->job_change_mail_body;
+                break;
+
+            case config('constants.hr.application-meta.keys.round-not-conducted'):
+                $attr['modal-id'] = 'round_not_conducted_' . $this->id;
+                $attr['mail-subject'] = $this->value->mail_subject;
+                $attr['mail-body'] = $this->value->mail_body;
+                break;
+
+            default:
+                return false;
         }
-        $this->load('application', 'application.applicant');
 
-        return [
-            'modal-id' => 'round_not_conducted_' . $this->id,
-            'mail-to' => $this->application->applicant->email,
-            'mail-subject' => $this->value->mail_subject,
-            'mail-body' => $this->value->mail_body,
-            'mail-sender' => $this->value->user,
-            'mail-date' => $this->created_at,
-        ];
+        return $attr;
     }
 }

--- a/app/Models/HR/ApplicationMeta.php
+++ b/app/Models/HR/ApplicationMeta.php
@@ -26,6 +26,11 @@ class ApplicationMeta extends Model
         return $query->where('key', config('constants.hr.application-meta.keys.change-job'));
     }
 
+    public static function scopeRoundNotConducted($query)
+    {
+        return $query->where('key', config('constants.hr.application-meta.keys.round-not-conducted'));
+    }
+
     /**
      * Get details of communication mail if application meta is for change job
      *
@@ -43,6 +48,23 @@ class ApplicationMeta extends Model
             'mail-to' => $this->application->applicant->email,
             'mail-subject' => $this->value->job_change_mail_subject,
             'mail-body' => $this->value->job_change_mail_body,
+            'mail-sender' => $this->value->user,
+            'mail-date' => $this->created_at,
+        ];
+    }
+
+    public function getRoundNotConductedCommunicationMailAttribute()
+    {
+        if ($this->key != config('constants.hr.application-meta.keys.round-not-conducted')) {
+            return false;
+        }
+        $this->load('application', 'application.applicant');
+
+        return [
+            'modal-id' => 'round_not_conducted_' . $this->id,
+            'mail-to' => $this->application->applicant->email,
+            'mail-subject' => $this->value->mail_subject,
+            'mail-body' => $this->value->mail_body,
             'mail-sender' => $this->value->user,
             'mail-date' => $this->created_at,
         ];

--- a/app/Models/HR/ApplicationRound.php
+++ b/app/Models/HR/ApplicationRound.php
@@ -135,4 +135,19 @@ class ApplicationRound extends Model
             'mail-date' => $this->mail_sent_at,
         ];
     }
+
+    public function getRoundNotConductedAttribute()
+    {
+        if ($this->round_status) {
+            return null;
+        }
+
+        $scheduledDate = Carbon::parse($this->scheduled_date);
+        if ($scheduledDate < Carbon::now()->subHours(2)) {
+            return true;
+        }
+
+        return null;
+
+    }
 }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -7,4 +7,12 @@ use Illuminate\Database\Eloquent\Model;
 class Setting extends Model
 {
     protected $fillable = ['module', 'setting_key', 'setting_value'];
+
+    public static function getRoundNotConductedEmail()
+    {
+        return [
+            'subject' => self::where('setting_key', 'round_not_conducted_mail_subject')->first()->setting_value ?? null,
+            'body' => self::where('setting_key', 'round_not_conducted_mail_body')->first()->setting_value ?? null
+        ];
+    }
 }

--- a/config/constants.php
+++ b/config/constants.php
@@ -26,6 +26,7 @@ return [
             'keys' => [
                 'form-data' => 'form-data',
                 'change-job' => 'change-job',
+                'round-not-conducted' => 'round-not-conducted'
             ]
         ],
         'status' => [

--- a/config/constants.php
+++ b/config/constants.php
@@ -27,7 +27,11 @@ return [
                 'form-data' => 'form-data',
                 'change-job' => 'change-job',
                 'round-not-conducted' => 'round-not-conducted'
-            ]
+            ],
+            'reasons-round-not-conducted' => [
+                'absent-applicant' => 'Applicant is absent',
+                'absent-interviewer' => 'Interviewer is absent',
+            ],
         ],
         'status' => [
             'new' => [

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -171,26 +171,29 @@ input[type="file"] {
     z-index: 0;
 }
 
+.icon-pencil {
+    cursor: pointer;
+    padding: 8px;
+    border-radius: 50%;
+    height: 30px;
+    width: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+        background-color: $primary;
+        color: white;
+    }
+}
+
 .card-edit {
     position: absolute;
     right: 15px;
     top: 10px;
 
     &.icon-pencil {
-        cursor: pointer;
         top: 7px;
-        padding: 8px;
-        border-radius: 50%;
-        height: 30px;
-        width: 30px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-
-    &.icon-pencil:hover {
-        background-color: $primary;
-        color: white;
     }
 }
 
@@ -299,7 +302,7 @@ input:focus + .slider {
         width: 45vw;
         left: 0;
         top: 0;
-        z-index: 100;    
+        z-index: 100;
     }
     >.card-body {
         height: 100%;

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -93,35 +93,38 @@
                     $applicationRoundReviewValue = $applicationRoundReview ? $applicationRoundReview->review_value : '';
                 @endphp
                 <br>
-                <form action="/hr/applications/rounds/{{ $applicationRound->id }}" method="POST" class="applicant-round-form">
-
-                    {{ csrf_field() }}
-                    {{ method_field('PATCH') }}
-
-                    <div class="card">
-                        <div class="card-header c-pointer d-flex align-items-center justify-content-between" data-toggle="collapse" data-target="#collapse_{{ $loop->iteration }}">
-                            <div class="d-flex flex-column">
-                                <div>
-                                    {{ $applicationRound->round->name }}
-                                    <span title="{{ $applicationRound->round->name }} guide" class="modal-toggler-text text-muted" data-toggle="modal" data-target="#round_guide_{{ $applicationRound->round->id }}">
-                                        <i class="fa fa-info-circle fa-lg"></i>
-                                    </span>
-                                </div>
-                                @if ($applicationRound->round_status)
-                                    <span>Conducted By: {{ $applicationRound->conductedPerson->name }}</span>
-                                @endif
+                <div class="card">
+                    <div class="card-header c-pointer d-flex align-items-center justify-content-between" data-toggle="collapse" data-target="#collapse_{{ $loop->iteration }}">
+                        <div class="d-flex flex-column">
+                            <div>
+                                {{ $applicationRound->round->name }}
+                                <span title="{{ $applicationRound->round->name }} guide" class="modal-toggler-text text-muted" data-toggle="modal" data-target="#round_guide_{{ $applicationRound->round->id }}">
+                                    <i class="fa fa-info-circle fa-lg"></i>
+                                </span>
                             </div>
-                            <div class="d-flex flex-column align-items-end">
-                                @if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
-                                    <div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>
-                                @elseif ($applicationRound->round_status == config('constants.hr.status.rejected.label'))
-                                    <div class="text-danger"><i class="fa fa-close"></i>&nbsp;{{ config('constants.hr.status.rejected.title') }}</div>
-                                @endif
-                                @if ($applicationRound->round_status && $applicationRound->conducted_date)
-                                    <span>Conducted on: {{ date(config('constants.display_date_format', strtotime($applicationRound->conducted_date))) }}</span>
-                                @endif
-                            </div>
+                            @if ($applicationRound->round_status)
+                                <span>Conducted By: {{ $applicationRound->conductedPerson->name }}</span>
+                            @endif
                         </div>
+                        <div class="d-flex flex-column align-items-end">
+
+                            @includeWhen(true, 'hr.round-not-conducted-modal')
+
+                            @if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
+                                <div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>
+                            @elseif ($applicationRound->round_status == config('constants.hr.status.rejected.label'))
+                                <div class="text-danger"><i class="fa fa-close"></i>&nbsp;{{ config('constants.hr.status.rejected.title') }}</div>
+                            @endif
+                            @if ($applicationRound->round_status && $applicationRound->conducted_date)
+                                <span>Conducted on: {{ date(config('constants.display_date_format', strtotime($applicationRound->conducted_date))) }}</span>
+                            @endif
+                        </div>
+                    </div>
+
+                    <form action="/hr/applications/rounds/{{ $applicationRound->id }}" method="POST" class="applicant-round-form">
+
+                        {{ csrf_field() }}
+                        {{ method_field('PATCH') }}
                         <div id="collapse_{{ $loop->iteration }}" class="collapse {{ $loop->last ? 'show' : '' }}">
                             <div class="card-body">
                                 @if (!$applicationRound->round_status)
@@ -198,10 +201,10 @@
                             </div>
                             @endif
                         </div>
-                    </div>
-                    <input type="hidden" name="action" value="updated">
-                    @includeWhen($applicationRound->round_status != config('constants.hr.status.confirmed.label'), 'hr.round-review-confirm-modal', ['applicationRound' => $applicationRound])
-                </form>
+                        <input type="hidden" name="action" value="updated">
+                        @includeWhen($applicationRound->round_status != config('constants.hr.status.confirmed.label'), 'hr.round-review-confirm-modal', ['applicationRound' => $applicationRound])
+                    </form>
+                </div>
                 @include('hr.round-guide-modal', ['round' => $applicationRound->round])
                 @includeWhen($applicationRound->round_status && !$applicationRound->mail_sent, 'hr.round-review-mail-modal', ['applicantRound' => $applicationRound])
             @endforeach

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -94,7 +94,7 @@
                 @endphp
                 <br>
                 <div class="card">
-                    <div class="card-header c-pointer d-flex align-items-center justify-content-between" data-toggle="collapse" data-target="#collapse_{{ $loop->iteration }}">
+                    <div class="card-header d-flex align-items-center justify-content-between">
                         <div class="d-flex flex-column">
                             <div>
                                 {{ $applicationRound->round->name }}
@@ -106,18 +106,20 @@
                                 <span>Conducted By: {{ $applicationRound->conductedPerson->name }}</span>
                             @endif
                         </div>
-                        <div class="d-flex flex-column align-items-end">
+                        <div class="d-flex align-items-center">
+                            <div class="d-flex flex-column align-items-end">
+                                @includeWhen($applicationRound->roundNotConducted, 'hr.round-not-conducted-modal')
 
-                            @includeWhen($applicationRound->roundNotConducted, 'hr.round-not-conducted-modal')
-
-                            @if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
-                                <div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>
-                            @elseif ($applicationRound->round_status == config('constants.hr.status.rejected.label'))
-                                <div class="text-danger"><i class="fa fa-close"></i>&nbsp;{{ config('constants.hr.status.rejected.title') }}</div>
-                            @endif
-                            @if ($applicationRound->round_status && $applicationRound->conducted_date)
-                                <span>Conducted on: {{ date(config('constants.display_date_format', strtotime($applicationRound->conducted_date))) }}</span>
-                            @endif
+                                @if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
+                                    <div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>
+                                @elseif ($applicationRound->round_status == config('constants.hr.status.rejected.label'))
+                                    <div class="text-danger"><i class="fa fa-close"></i>&nbsp;{{ config('constants.hr.status.rejected.title') }}</div>
+                                @endif
+                                @if ($applicationRound->round_status && $applicationRound->conducted_date)
+                                    <span>Conducted on: {{ date(config('constants.display_date_format', strtotime($applicationRound->conducted_date))) }}</span>
+                                @endif
+                            </div>
+                            <div class="icon-pencil position-relative ml-3" data-toggle="collapse" data-target="#collapse_{{ $loop->iteration }}"><i class="fa fa-pencil"></i></div>
                         </div>
                     </div>
 

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -108,7 +108,7 @@
                         </div>
                         <div class="d-flex flex-column align-items-end">
 
-                            @includeWhen(true, 'hr.round-not-conducted-modal')
+                            @includeWhen($applicationRound->roundNotConducted, 'hr.round-not-conducted-modal')
 
                             @if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
                                 <div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>

--- a/resources/views/hr/application/timeline.blade.php
+++ b/resources/views/hr/application/timeline.blade.php
@@ -35,6 +35,16 @@
                         <span data-toggle="modal" data-target="#{{ $event->jobChangedCommunicationMail['modal-id'] }}" class="{{ config("constants.hr.status.rejected.class") }} modal-toggler">Communication mail</span><br>
                         @include('hr.communication-mail-modal', ['data' => $event->jobChangedCommunicationMail])
                         @break
+                    @case('round-not-conducted')
+                        @php
+                            $event = $item['event'];
+                        @endphp
+                        <b><u>{{ date(config('constants.display_date_format'), strtotime($item['date'])) }}</u></b><br>
+                        Round not conducted: {{ $event->value->round }}<br>
+                        Reason: {{ $event->value->reason }}<br>
+                        <span data-toggle="modal" data-target="#{{ $event->roundNotConductedCommunicationMail['modal-id'] }}" class="{{ config("constants.hr.status.rejected.class") }} modal-toggler">Communication mail</span><br>
+                        @include('hr.communication-mail-modal', ['data' => $event->roundNotConductedCommunicationMail])
+                        @break
                 @endswitch
             </div>
         </div>

--- a/resources/views/hr/application/timeline.blade.php
+++ b/resources/views/hr/application/timeline.blade.php
@@ -14,6 +14,7 @@
                             @include('hr.application.auto-respond', ['applicant' => $application->applicant, 'application' => $application])
                         @endif
                         @break
+
                     @case('round-conducted')
                         @php
                             $applicationRound = $item['applicationRound'];
@@ -26,24 +27,26 @@
                             @include('hr.communication-mail-modal', [ 'data' => $applicationRound->communicationMail ])
                         @endif
                         @break
-                    @case('job-changed')
+
+                    @case(config('constants.hr.application-meta.keys.change-job'))
                         @php
                             $event = $item['event'];
                         @endphp
                         <b><u>{{ date(config('constants.display_date_format'), strtotime($item['date'])) }}</u></b><br>
                         Moved from {{ $event->value->previous_job }} to {{ $event->value->new_job }}<br>
-                        <span data-toggle="modal" data-target="#{{ $event->jobChangedCommunicationMail['modal-id'] }}" class="{{ config("constants.hr.status.rejected.class") }} modal-toggler">Communication mail</span><br>
-                        @include('hr.communication-mail-modal', ['data' => $event->jobChangedCommunicationMail])
+                        <span data-toggle="modal" data-target="#{{ $event->communicationMail['modal-id'] }}" class="{{ config("constants.hr.status.rejected.class") }} modal-toggler">Communication mail</span><br>
+                        @include('hr.communication-mail-modal', ['data' => $event->communicationMail])
                         @break
-                    @case('round-not-conducted')
+
+                    @case(config('constants.hr.application-meta.keys.round-not-conducted'))
                         @php
                             $event = $item['event'];
                         @endphp
                         <b><u>{{ date(config('constants.display_date_format'), strtotime($item['date'])) }}</u></b><br>
                         Round not conducted: {{ $event->value->round }}<br>
-                        Reason: {{ $event->value->reason }}<br>
-                        <span data-toggle="modal" data-target="#{{ $event->roundNotConductedCommunicationMail['modal-id'] }}" class="{{ config("constants.hr.status.rejected.class") }} modal-toggler">Communication mail</span><br>
-                        @include('hr.communication-mail-modal', ['data' => $event->roundNotConductedCommunicationMail])
+                        Reason: {{ config('constants.hr.application-meta.reasons-round-not-conducted.' . $event->value->reason) }}<br>
+                        <span data-toggle="modal" data-target="#{{ $event->communicationMail['modal-id'] }}" class="{{ config("constants.hr.status.rejected.class") }} modal-toggler">Communication mail</span><br>
+                        @include('hr.communication-mail-modal', ['data' => $event->communicationMail])
                         @break
                 @endswitch
             </div>

--- a/resources/views/hr/round-not-conducted-modal.blade.php
+++ b/resources/views/hr/round-not-conducted-modal.blade.php
@@ -18,8 +18,9 @@
 						<div class="form-group col-md-6">
 							<label for="round_not_conducted_reason">Select reason</label>
 							<select name="round_not_conducted_reason" id="round_not_conducted_reason" class="form-control">
-								<option value="absent-applicant">Applicant was absent</option>
-								<option value="absent-interviewer">The interviewer was absent</option>
+							@foreach(config('constants.hr.application-meta.reasons-round-not-conducted') as $reason => $reasonTitle)
+								<option value="{{ $reason }}">{{ $reasonTitle }}</option>
+							@endforeach
 							</select>
 						</div>
 					</div>

--- a/resources/views/hr/round-not-conducted-modal.blade.php
+++ b/resources/views/hr/round-not-conducted-modal.blade.php
@@ -27,13 +27,13 @@
 					<div class="form-row mt-4">
 						<div class="form-group col-md-12">
 							<label for="round_not_conducted_mail_subject">Mail subject:</label>
-							<input type="text" name="round_not_conducted_mail_subject" class="form-control" placeholder="Subject" required="required">
+							<input type="text" name="round_not_conducted_mail_subject" class="form-control" placeholder="Subject" required="required" value="{{ $settings['roundNotConducted']['subject'] }}">
 						</div>
 					</div>
 					<div class="form-row">
 						<div class="form-group col-md-12">
 							<label for="round_not_conducted_mail_body">Mail body:</label>
-							<textarea name="round_not_conducted_mail_body" class="richeditor form-control" rows="10"></textarea>
+							<textarea name="round_not_conducted_mail_body" class="richeditor form-control" rows="10">{{ $settings['roundNotConducted']['body'] }}</textarea>
 						</div>
 					</div>
 					<div class="form-row mt-2">

--- a/resources/views/hr/round-not-conducted-modal.blade.php
+++ b/resources/views/hr/round-not-conducted-modal.blade.php
@@ -1,4 +1,4 @@
-<span class="text-danger c-pointer" data-toggle="modal" data-target="#myModal">Interview not conducted</span>
+<span class="text-danger c-pointer" data-toggle="modal" data-target="#myModal"><i class="fa fa-warning fa-lg"></i>&nbsp;Interview not conducted</span>
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModal" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">

--- a/resources/views/hr/round-not-conducted-modal.blade.php
+++ b/resources/views/hr/round-not-conducted-modal.blade.php
@@ -1,0 +1,49 @@
+<span class="text-danger c-pointer" data-toggle="modal" data-target="#myModal">Interview not conducted</span>
+<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModal" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+			<h5 class="modal-title" id="myModal">Interview not conducted</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+				<form action="{{ route('applications.job.update', $application->id) }}" method="POST">
+
+					{{ csrf_field() }}
+					{{ method_field('PATCH') }}
+
+					<div class="form-row">
+						<div class="form-group col-md-6">
+							<label for="round_not_conducted_reason">Select reason</label>
+							<select name="round_not_conducted_reason" id="round_not_conducted_reason" class="form-control">
+								<option value="absent-applicant">Applicant was absent</option>
+								<option value="absent-interviewer">The interviewer was absent</option>
+							</select>
+						</div>
+					</div>
+					<div class="form-row mt-4">
+						<div class="form-group col-md-12">
+							<label for="round_not_conducted_mail_subject">Mail subject:</label>
+							<input type="text" name="round_not_conducted_mail_subject" class="form-control" placeholder="Subject" required="required">
+						</div>
+					</div>
+					<div class="form-row">
+						<div class="form-group col-md-12">
+							<label for="round_not_conducted_mail_body">Mail body:</label>
+							<textarea name="round_not_conducted_mail_body" class="richeditor form-control" rows="10"></textarea>
+						</div>
+					</div>
+					<div class="form-row mt-2">
+						<div class="form-group col-md-12">
+							<input type="hidden" name="application_round_id" value="{{ $applicationRound->id }}">
+							<input type="hidden" name="action" value="{{ config('constants.hr.application-meta.keys.round-not-conducted') }}">
+							<button type="submit" class="btn btn-primary px-4">Save</button>
+						</div>
+					</div>
+				</form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/settings/hr.blade.php
+++ b/resources/views/settings/hr.blade.php
@@ -8,36 +8,9 @@
     <h1>Mail Templates</h1>
     <br>
     @include('status', ['errors' => $errors->all()])
-    <div class="card">
-        <form action="{{ url('/settings/hr/update') }}" method="POST">
-            {{ csrf_field() }}
-
-            <div class="card-header c-pointer" data-toggle="collapse" data-target="#applicant_autoresponder" aria-expanded="true" aria-controls="applicant_autoresponder">Auto responder mail to applicant</div>
-            <div id="applicant_autoresponder" class="collapse">
-                <div class="card-body">
-                    <div class="form-row">
-                        <div class="col-md-12">
-                            <div class="form-group">
-                                <label for="setting_key[applicant_create_autoresponder_subject]">Subject</label>
-                                <input type="text" name="setting_key[applicant_create_autoresponder_subject]" class="form-control" value="{{ isset($settings['applicant_create_autoresponder_subject']->setting_value) ? $settings['applicant_create_autoresponder_subject']->setting_value : '' }}">
-                            </div>
-                        </div>
-                    </div>
-                    <div class="form-row">
-                        <div class="col-md-12">
-                            <div class="form-group">
-                                <label for="setting_key[applicant_create_autoresponder_body]">Mail body:</label>
-                                <textarea name="setting_key[applicant_create_autoresponder_body]" rows="10" class="richeditor form-control" placeholder="Body">{{ isset($settings['applicant_create_autoresponder_body']->setting_value) ? $settings['applicant_create_autoresponder_body']->setting_value : '' }}</textarea>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="card-footer">
-                    <button type="submit" class="btn btn-primary">Save</button>
-                </div>
-            </div>
-        </form>
-    </div>
+    <br>
+    @include('settings.hr.applicant-auto-responder')
+    @include('settings.hr.round-not-conducted')
     <h4 class="mt-5">Mail templates for rounds</h4>
     @foreach ($rounds as $index => $round)
         @foreach ($roundMailTypes as $type)

--- a/resources/views/settings/hr/applicant-auto-responder.blade.php
+++ b/resources/views/settings/hr/applicant-auto-responder.blade.php
@@ -1,0 +1,31 @@
+<div class="card">
+	<form action="{{ url('/settings/hr/update') }}" method="POST">
+
+		{{ csrf_field() }}
+
+		<div class="card-header c-pointer" data-toggle="collapse" data-target="#applicant_autoresponder" aria-expanded="true" aria-controls="applicant_autoresponder">Auto responder mail to applicant</div>
+		<div id="applicant_autoresponder" class="collapse">
+			<div class="card-body">
+				<div class="form-row">
+					<div class="col-md-12">
+						<div class="form-group">
+							<label for="setting_key[applicant_create_autoresponder_subject]">Subject</label>
+							<input type="text" name="setting_key[applicant_create_autoresponder_subject]" class="form-control" value="{{ isset($settings['applicant_create_autoresponder_subject']->setting_value) ? $settings['applicant_create_autoresponder_subject']->setting_value : '' }}">
+						</div>
+					</div>
+				</div>
+				<div class="form-row">
+					<div class="col-md-12">
+						<div class="form-group">
+							<label for="setting_key[applicant_create_autoresponder_body]">Mail body:</label>
+							<textarea name="setting_key[applicant_create_autoresponder_body]" rows="10" class="richeditor form-control" placeholder="Body">{{ isset($settings['applicant_create_autoresponder_body']->setting_value) ? $settings['applicant_create_autoresponder_body']->setting_value : '' }}</textarea>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="card-footer">
+				<button type="submit" class="btn btn-primary">Save</button>
+			</div>
+		</div>
+	</form>
+</div>

--- a/resources/views/settings/hr/round-not-conducted.blade.php
+++ b/resources/views/settings/hr/round-not-conducted.blade.php
@@ -1,0 +1,31 @@
+<div class="card mt-4">
+	<form action="{{ url('/settings/hr/update') }}" method="POST">
+
+		{{ csrf_field() }}
+
+		<div class="card-header c-pointer" data-toggle="collapse" data-target="#applicant_pre_interview_reminder" aria-expanded="true" aria-controls="applicant_pre_interview_reminder">Round not conducted email to Applicant</div>
+		<div id="applicant_pre_interview_reminder" class="collapse">
+			<div class="card-body">
+				<div class="form-row">
+					<div class="col-md-12">
+						<div class="form-group">
+							<label for="setting_key[round_not_conducted_mail_subject]">Subject</label>
+							<input type="text" name="setting_key[round_not_conducted_mail_subject]" class="form-control" value="{{ isset($settings['round_not_conducted_mail_subject']->setting_value) ? $settings['round_not_conducted_mail_subject']->setting_value : '' }}">
+						</div>
+					</div>
+				</div>
+				<div class="form-row">
+					<div class="col-md-12">
+						<div class="form-group">
+							<label for="setting_key[round_not_conducted_mail_body]">Mail body:</label>
+							<textarea name="setting_key[round_not_conducted_mail_body]" rows="10" class="richeditor form-control" placeholder="Body">{{ isset($settings['round_not_conducted_mail_body']->setting_value) ? $settings['round_not_conducted_mail_body']->setting_value : '' }}</textarea>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="card-footer">
+				<button type="submit" class="btn btn-primary">Save</button>
+			</div>
+		</div>
+	</form>
+</div>


### PR DESCRIPTION
#285 

Changes include:

1. Ability to send mail to an applicant when the applicant or interviewer misses the interview.
2. The system marks an interview as not-conducted if, after two hours of scheduled time, the status is still not confirmed/rejected.
3. The user needs to fill the reason as well and all the details are saved in the application meta table.
4. This event also gets displayed in the applicant's timeline.