### PR TITLE
(#311) no show scheduling

### DIFF
--- a/app/Console/Commands/HR/ApplicationNoShow.php
+++ b/app/Console/Commands/HR/ApplicationNoShow.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands\HR;
+
+use Illuminate\Console\Command;
+use Carbon\Carbon;
+use App\Models\HR\ApplicationRound;
+use App\Models\HR\ApplicationMeta;
+
+class ApplicationNoShow extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'application:no-show';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set application status to no-show if an application round is not conducted 2 hours after scheduled time';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $applicationRounds = ApplicationRound::with('application')->whereNull('round_status')
+                            ->whereDate('scheduled_date', '=', Carbon::today()->toDateString())
+                            ->get();
+
+        foreach ($applicationRounds as $applicationRound) {
+            $application = $applicationRound->application;
+            if ($application->status != 'no-show') {
+                $application->update([
+                    'status' => 'no-show'
+                ]);
+                $roundNotConductedMeta = ApplicationMeta::create([
+                    'hr_application_id' => $application->id,
+                    'key' => config('constants.hr.application-meta.keys.no-show'),
+                    'value' => json_encode([
+                        'round' => $applicationRound->id,
+                    ]),
+                ]);
+            }
+        }
+    }
+}

--- a/app/Console/Commands/HR/ApplicationNoShow.php
+++ b/app/Console/Commands/HR/ApplicationNoShow.php
@@ -40,8 +40,9 @@ class ApplicationNoShow extends Command
      */
     public function handle()
     {
-        $applicationRounds = ApplicationRound::with('application')->whereNull('round_status')
-                            ->whereDate('scheduled_date', '=', Carbon::today()->toDateString())
+        $applicationRounds = ApplicationRound::with('application')
+                            ->whereNull('round_status')
+                            ->where('scheduled_date', '<=', Carbon::now()->subHours(config('constants.hr.no-show-hours-limit'))->toDateTimeString())
                             ->get();
 
         foreach ($applicationRounds as $applicationRound) {

--- a/app/Console/Commands/HR/ApplicationNoShow.php
+++ b/app/Console/Commands/HR/ApplicationNoShow.php
@@ -48,9 +48,7 @@ class ApplicationNoShow extends Command
         foreach ($applicationRounds as $applicationRound) {
             $application = $applicationRound->application;
             if ($application->status != config('constants.hr.application-meta.keys.no-show')) {
-                $application->update([
-                    'status' => config('constants.hr.application-meta.keys.no-show')
-                ]);
+                $application->markNoShow();
                 $roundNotConductedMeta = ApplicationMeta::create([
                     'hr_application_id' => $application->id,
                     'key' => config('constants.hr.application-meta.keys.no-show'),

--- a/app/Console/Commands/HR/ApplicationNoShow.php
+++ b/app/Console/Commands/HR/ApplicationNoShow.php
@@ -47,9 +47,9 @@ class ApplicationNoShow extends Command
 
         foreach ($applicationRounds as $applicationRound) {
             $application = $applicationRound->application;
-            if ($application->status != 'no-show') {
+            if ($application->status != config('constants.hr.application-meta.keys.no-show')) {
                 $application->update([
-                    'status' => 'no-show'
+                    'status' => config('constants.hr.application-meta.keys.no-show')
                 ]);
                 $roundNotConductedMeta = ApplicationMeta::create([
                     'hr_application_id' => $application->id,

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,8 +24,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')
-        //          ->hourly();
+        $schedule->command('application:no-show')
+                 ->everyThirtyMinutes();
     }
 
     /**

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -95,7 +95,10 @@ class Application extends Model
                 break;
             case config('constants.hr.status.on-hold.label'):
                 $query->onHold();
-                break;    
+                break;
+            case config('constants.hr.status.no-show.label'):
+                $query->noShow();
+                break;
             default:
                 $query->isOpen();
                 break;
@@ -159,6 +162,14 @@ class Application extends Model
     public function scopeOnHold($query)
     {
         return $query->where('status', config('constants.hr.status.on-hold.label'));
+    }
+
+    /**
+     * get applications where status is no-show
+     */
+    public function scopeNoShow($query)
+    {
+        return $query->where('status', config('constants.hr.status.no-show.label'));
     }
 
     /**

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -217,7 +217,9 @@ class Application extends Model
         foreach ($noShowEvents as $event) {
             $details = json_decode($event->value);
             $details->round = ApplicationRound::find($details->round)->round->name;
-            $details->user = User::find($details->user)->name;
+            if (isset($details->user)) {
+                $details->user = User::find($details->user)->name;
+            }
             $event->value = $details;
             $timeline[] = [
                 'type' => config('constants.hr.application-meta.keys.no-show'),

--- a/app/Models/HR/Application.php
+++ b/app/Models/HR/Application.php
@@ -189,6 +189,14 @@ class Application extends Model
     }
 
     /**
+     * Set the application status to no-show
+     */
+    public function markNoShow()
+    {
+        $this->update(['status' => config('constants.hr.status.no-show.label')]);
+    }
+
+    /**
      * Get the timeline for an application
      *
      * @return array

--- a/app/Models/HR/ApplicationMeta.php
+++ b/app/Models/HR/ApplicationMeta.php
@@ -42,8 +42,8 @@ class ApplicationMeta extends Model
 
         $attr = [
             'mail-to' => $this->application->applicant->email,
-            'mail-sender' => $this->value->user,
-            'mail-date' => $this->created_at,
+            'mail-sender' => $this->value->user ?? null,
+            'mail-date' => $this->updated_at,
         ];
 
         switch ($this->key) {
@@ -55,8 +55,8 @@ class ApplicationMeta extends Model
 
             case config('constants.hr.application-meta.keys.no-show'):
                 $attr['modal-id'] = 'round_not_conducted_' . $this->id;
-                $attr['mail-subject'] = $this->value->mail_subject;
-                $attr['mail-body'] = $this->value->mail_body;
+                $attr['mail-subject'] = $this->value->mail_subject ?? null;
+                $attr['mail-body'] = $this->value->mail_body ?? null;
                 break;
 
             default:

--- a/config/constants.php
+++ b/config/constants.php
@@ -45,6 +45,11 @@ return [
                 'title' => 'On hold',
                 'class' => 'badge badge-secondary'
             ],
+            'no-show' => [
+                'label' => 'no-show',
+                'title' => 'No show',
+                'class' => 'badge badge-danger'
+            ],
             'rejected' => [
                 'label' => 'rejected',
                 'title' => 'Rejected',

--- a/resources/views/hr/application/index.blade.php
+++ b/resources/views/hr/application/index.blade.php
@@ -13,7 +13,10 @@
                 <a class="nav-item nav-link {{ $status ? 'text-info' : 'active bg-info text-white' }}" href="/{{ Request::path() }}/"><i class="fa fa-clipboard"></i>&nbsp;Open</a>
             </li>
             <li class="nav-item">
-                <a class="nav-item nav-link {{ $status === config('constants.hr.status.on-hold.label') ? 'active bg-info text-white' : 'text-info' }}" href="/{{ Request::path() }}?status={{ config('constants.hr.status.on-hold.label') }}"><i class="fa fa-file-text-o"></i>&nbsp;On hold</a>
+                <a class="nav-item nav-link {{ $status === config('constants.hr.status.on-hold.label') ? 'active bg-info text-white' : 'text-info' }}" href="/{{ Request::path() }}?status={{ config('constants.hr.status.on-hold.label') }}"><i class="fa fa-file-text-o"></i>&nbsp;{{ config('constants.hr.status.on-hold.title') }}</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-item nav-link {{ $status === config('constants.hr.status.no-show.label') ? 'active bg-info text-white' : 'text-info' }}" href="/{{ Request::path() }}?status={{ config('constants.hr.status.no-show.label') }}"><i class="fa fa-warning"></i>&nbsp;{{ config('constants.hr.status.no-show.title') }}</a>
             </li>
             <li class="nav-item">
                 <a class="nav-item nav-link {{ $status === config('constants.hr.status.rejected.label') ? 'active bg-info text-white' : 'text-info' }}" href="/{{ Request::path() }}?status={{ config('constants.hr.status.rejected.label') }}"><i class="fa fa-times-circle"></i>&nbsp;Closed</a>
@@ -25,7 +28,7 @@
         </div>
         @endif
     </div>
-    
+
     <table class="table table-striped table-bordered" id="applicants_table">
         <tr>
             <th>Name</th>

--- a/resources/views/hr/application/timeline.blade.php
+++ b/resources/views/hr/application/timeline.blade.php
@@ -43,10 +43,14 @@
                             $event = $item['event'];
                         @endphp
                         <b><u>{{ date(config('constants.display_date_format'), strtotime($item['date'])) }}</u></b><br>
-                        Round not conducted: {{ $event->value->round }}<br>
-                        Reason: {{ config('constants.hr.application-meta.reasons-no-show.' . $event->value->reason) }}<br>
-                        <span data-toggle="modal" data-target="#{{ $event->communicationMail['modal-id'] }}" class="{{ config("constants.hr.status.rejected.class") }} modal-toggler">Communication mail</span><br>
-                        @include('hr.communication-mail-modal', ['data' => $event->communicationMail])
+                        No show: {{ $event->value->round }}<br>
+                        @if (isset($event->value->reason))
+                            Reason: {{ config('constants.hr.application-meta.reasons-no-show.' . $event->value->reason) }}<br>
+                        @endif
+                        @if (isset($event->communicationMail['mail-subject']) && !is_null($event->communicationMail['mail-subject']) )
+                            <span data-toggle="modal" data-target="#{{ $event->communicationMail['modal-id'] }}" class="{{ config("constants.hr.status.rejected.class") }} modal-toggler">Communication mail</span><br>
+                            @include('hr.communication-mail-modal', ['data' => $event->communicationMail])
+                        @endif
                         @break
                 @endswitch
             </div>


### PR DESCRIPTION
#311 

Changes include:

1. Artisan command that changes application status to no-show if an application round that was scheduled 2 hours ago is still not conducted.
2. Task scheduler that calls the above artisan command every 30 minutes.
3. Changes in applicant timeline when the cron runs.

Steps for deployment:
1. Add the following cronjob
```
* * * * * php path_to_employee_portal/artisan schedule:run >> /dev/null 2>&1
```