### PR TITLE
(#285) interview reminder enable

### DIFF
--- a/app/Console/Commands/HR/SendInterviewReminders.php
+++ b/app/Console/Commands/HR/SendInterviewReminders.php
@@ -54,7 +54,9 @@ class SendInterviewReminders extends Command
 
             // send reminder emails to the applicant for each application round
             foreach ($rounds as $applicationRound) {
-                Mail::send(new ScheduledInterviewReminder($applicationRound));
+                if ($applicationRound->round->reminder_enabled) {
+                    Mail::send(new ScheduledInterviewReminder($applicationRound));
+                }
             }
         }
     }

--- a/database/migrations/2018_06_04_120633_update_round_table_reminder_enabled_column.php
+++ b/database/migrations/2018_06_04_120633_update_round_table_reminder_enabled_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateRoundTableReminderEnabledColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('hr_rounds', function (Blueprint $table) {
+            $table->boolean('reminder_enabled')->default(false)->after('guidelines');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('hr_rounds', function (Blueprint $table) {
+            $table->dropColumn(['reminder_enabled']);
+        });
+    }
+}


### PR DESCRIPTION
#285

We need to send reminders to applicants for all rounds except a few (like resume screening). So, we need a flag that'll track this.
