### PR TITLE
(#401) bug in scheduler

### DIFF
--- a/app/Models/HR/ApplicationRound.php
+++ b/app/Models/HR/ApplicationRound.php
@@ -182,6 +182,7 @@ class ApplicationRound extends Model
                     config('constants.hr.status.no-show.label'),
                 ]);
             })
+            ->whereNull('round_status')
             ->whereDate('scheduled_date', '=', Carbon::today()->toDateString())
             ->orderBy('scheduled_date')
             ->get();


### PR DESCRIPTION
#401 

Apparently, the scheduler wasn't checking if the round was marked as conducted/rejected.