### PR TITLE
#337 moved reason for eligibility column

### DIFF
--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -2,8 +2,8 @@
 
 namespace App\Models\HR;
 
-use Illuminate\Database\Eloquent\Model;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
 
 class Applicant extends Model
 {
@@ -35,15 +35,15 @@ class Applicant extends Model
             'hr_job_id' => $job->id,
             'hr_applicant_id' => $applicant->id,
             'resume' => $attr['resume'],
-            'reason_for_eligibility' => isset($attr['reason_for_eligibility']) ? $attr['reason_for_eligibility'] : null,
             'status' => $applicant->wasRecentlyCreated ? config('constants.hr.status.new.label') : config('constants.hr.status.on-hold.label'),
         ]);
 
         if (isset($attr['form_data'])) {
             $application_meta = ApplicationMeta::create([
                 'hr_application_id' => $application->id,
+                'reason_for_eligibility' => isset($attr['reason_for_eligibility']) ? $attr['reason_for_eligibility'] : null,
                 'key' => config('constants.hr.application-meta.keys.form-data'),
-                'value' => json_encode($attr['form_data'])
+                'value' => json_encode($attr['form_data']),
             ]);
         }
 

--- a/database/migrations/2018_05_14_083216_create_hr_applications_table.php
+++ b/database/migrations/2018_05_14_083216_create_hr_applications_table.php
@@ -19,6 +19,7 @@ class CreateHrApplicationsTable extends Migration
             $table->unsignedInteger('hr_job_id');
             $table->string('status')->nullable();
             $table->string('resume')->nullable();
+            $table->text('reason_for_eligibility')->nullable();
             $table->string('autoresponder_subject')->nullable();
             $table->text('autoresponder_body')->nullable();
             $table->timestamps();

--- a/database/migrations/2018_05_14_083216_create_hr_applications_table.php
+++ b/database/migrations/2018_05_14_083216_create_hr_applications_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateHrApplicationsTable extends Migration
 {
@@ -19,7 +19,6 @@ class CreateHrApplicationsTable extends Migration
             $table->unsignedInteger('hr_job_id');
             $table->string('status')->nullable();
             $table->string('resume')->nullable();
-            $table->text('reason_for_eligibility')->nullable();
             $table->string('autoresponder_subject')->nullable();
             $table->text('autoresponder_body')->nullable();
             $table->timestamps();

--- a/database/migrations/2018_05_17_122653_add_h_r_application_meta_table.php
+++ b/database/migrations/2018_05_17_122653_add_h_r_application_meta_table.php
@@ -16,7 +16,6 @@ class AddHRApplicationMetaTable extends Migration
         Schema::create('hr_application_meta', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('hr_application_id');
-            $table->text('reason_for_eligibility')->nullable();
             $table->text('form_data');
             $table->timestamps();
         });

--- a/database/migrations/2018_05_17_122653_add_h_r_application_meta_table.php
+++ b/database/migrations/2018_05_17_122653_add_h_r_application_meta_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class AddHRApplicationMetaTable extends Migration
 {
@@ -16,6 +16,7 @@ class AddHRApplicationMetaTable extends Migration
         Schema::create('hr_application_meta', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('hr_application_id');
+            $table->text('reason_for_eligibility')->nullable();
             $table->text('form_data');
             $table->timestamps();
         });

--- a/database/migrations/2018_06_16_131156_remove_hr_application_reason_for_eligibility.php
+++ b/database/migrations/2018_06_16_131156_remove_hr_application_reason_for_eligibility.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RemoveHrApplicationReasonForEligibility extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('hr_applications', function (Blueprint $table) {
+            $table->dropColumn(['reason_for_eligibility']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('hr_applications', function (Blueprint $table) {
+            $table->text('reason_for_eligibility')->nullable();
+        });
+    }
+}

--- a/database/migrations/2018_06_16_131309_add_hr_application_meta_reason_for_eligibility.php
+++ b/database/migrations/2018_06_16_131309_add_hr_application_meta_reason_for_eligibility.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddHrApplicationMetaReasonForEligibility extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('hr_application_meta', function (Blueprint $table) {
+            $table->text('reason_for_eligibility')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('hr_application_meta', function (Blueprint $table) {
+            $table->dropColumn(['reason_for_eligibility']);
+        });
+    }
+}


### PR DESCRIPTION
moved "reason for eligibility" from hr_application to hr_application_meta
changes:
     1. In hr_application migration, removed following
     `$table->text('reason_for_eligibility')->nullable();`
     2. In hr_application_meta, added following
     `$table->text('reason_for_eligibility')->nullable();`
     3. In Applicant.php 
      `'reason_for_eligibility' => isset($attr['reason_for_eligibility']) ? $attr['reason_for_eligibility'] : null,` is 
       displaced from `Application::create` to `ApplicationMeta::create`
       means the data related to the **reason for eligibility** will be stored to **hr_applicatiion_meta**