### PR TITLE
441 Book Manager Role

### DIFF
--- a/database/seeds/BookManagerSeeder.php
+++ b/database/seeds/BookManagerSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class BookManagerSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $bookManager = Role::create(['name' => 'book-manager']);
+        $bookManager->syncPermissions(Permission::where('name', 'LIKE', 'library%')->get());
+    }
+}


### PR DESCRIPTION
#441 

Created a new seeder `BookManagerSeeder` that does the following:
1. Creates a new role called `book-manager`
1. Associates **all** the library (book and book category) permissions with this role

Command to run:
`> php artisan db:seed --class=BookManagerSeeder`

If it says _BookManagerSeeder does not exist_ or something like that, first run this command:
`> composer dump-autoload`
and then run the seeding command again.
