### PR TITLE
book card width increased for tablet screen (> 767px)

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -380,7 +380,8 @@ input:focus+.slider {
 @media (min-width: 768px) and (max-width: 1024px) {
     #books_listing {
         .book_card {
-            width: 32%;
+            width: 49%;
+            word-break: break-word;
         }
     }
 }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -380,7 +380,7 @@ input:focus+.slider {
 @media (min-width: 768px) and (max-width: 1024px) {
     #books_listing {
         .book_card {
-            width: 25%;
+            width: 32%;
         }
     }
 }


### PR DESCRIPTION
#482 

The book page for tablet screen appears broken. Here's the screenshot:
![screenshot 94](https://user-images.githubusercontent.com/11808845/42647168-cef32c12-8620-11e8-91c1-f3d8905bd864.png)

Problems:
1. The text (book title and author) is coming out of the book card.
1. There is some space missing at the end of each row of book cards
1. The size of book card is little small.


Did the following the changes:
1. used `word-break` to automatically break long words in the next line
1. increased the card-width to `49%` so that only two cards fit in the row and no space is left on the right

Here's how the page look after these changes:
![screenshot 93](https://user-images.githubusercontent.com/11808845/42646309-261eb1da-861e-11e8-864a-f0f457fd547f.png)
