### PR TITLE
g-suite require full name

### DIFF
--- a/app/Http/Controllers/HR/ApplicantController.php
+++ b/app/Http/Controllers/HR/ApplicantController.php
@@ -45,6 +45,7 @@ class ApplicantController extends Controller
     public function store(ApplicantRequest $request)
     {
         $validated = $request->validated();
+        $validated['name'] = $validated['first_name'] . ' ' . $validated['last_name']
         return Applicant::_create($validated);
     }
 

--- a/app/Http/Controllers/HR/ApplicantController.php
+++ b/app/Http/Controllers/HR/ApplicantController.php
@@ -45,7 +45,7 @@ class ApplicantController extends Controller
     public function store(ApplicantRequest $request)
     {
         $validated = $request->validated();
-        $validated['name'] = $validated['first_name'] . ' ' . $validated['last_name']
+        $validated['name'] = $validated['first_name'] . ' ' . $validated['last_name'];
         return Applicant::_create($validated);
     }
 

--- a/app/Http/Requests/HR/ApplicantRequest.php
+++ b/app/Http/Requests/HR/ApplicantRequest.php
@@ -24,12 +24,13 @@ class ApplicantRequest extends FormRequest
     public function rules()
     {
         $rules = [
-            'hr_job_id' => 'nullable|exists:hr_jobs,id'
+            'hr_job_id' => 'nullable|exists:hr_jobs,id',
         ];
 
         if ($this->method() === 'POST') {
             $rules = [
-                'name' => 'required|string',
+                'first_name' => 'required|string',
+                'last_name' => 'required|string',
                 'email' => 'required|email',
                 'phone' => 'nullable|string',
                 'resume' => 'required|url',
@@ -39,7 +40,7 @@ class ApplicantRequest extends FormRequest
                 'course' => 'nullable|string',
                 'linkedin' => 'nullable|url',
                 'reason_for_eligibility' => 'nullable|string',
-                'form_data' => 'nullable|array'
+                'form_data' => 'nullable|array',
             ];
         }
 

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -23,7 +23,7 @@ class Applicant extends Model
         $applicant = self::firstOrCreate([
             'email' => $attr['email'],
         ], [
-            'name' => $attr['name'],
+            'name' => $attr['first_name'] . ' ' . $attr['last_name'],
             'phone' => isset($attr['phone']) ? $attr['phone'] : null,
             'college' => isset($attr['college']) ? $attr['college'] : null,
             'graduation_year' => isset($attr['graduation_year']) ? $attr['graduation_year'] : null,

--- a/app/Models/HR/Applicant.php
+++ b/app/Models/HR/Applicant.php
@@ -23,7 +23,7 @@ class Applicant extends Model
         $applicant = self::firstOrCreate([
             'email' => $attr['email'],
         ], [
-            'name' => $attr['first_name'] . ' ' . $attr['last_name'],
+            'name' => $attr['name'],
             'phone' => isset($attr['phone']) ? $attr['phone'] : null,
             'college' => isset($attr['college']) ? $attr['college'] : null,
             'graduation_year' => isset($attr['graduation_year']) ? $attr['graduation_year'] : null,


### PR DESCRIPTION
#544 

- g-suite onboard problem solved
- now every applicant needs to fill `last_name` also .
 
- Client applications are requested to update these two field in employee_application form.     
     - remove
         -   `name`    
    - add 
        -  `first_name` 
        -  `last_name`

 