### PR TITLE
(#566) test case cleanups

### DIFF
--- a/tests/Feature/FeatureTest.php
+++ b/tests/Feature/FeatureTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -16,13 +15,8 @@ abstract class FeatureTest extends TestCase
         $this->setUpRolesAndPermissions();
     }
 
-    public function anAuthorizedUser($role = 'super-admin')
-    {
-        $this->signIn(create(User::class)->assignRole($role));
-    }
-
     public function signInAsSuperAdmin()
     {
-        $this->anAuthorizedUser();
+        $this->signIn('super-admin');
     }
 }

--- a/tests/Feature/FeatureTest.php
+++ b/tests/Feature/FeatureTest.php
@@ -19,4 +19,9 @@ abstract class FeatureTest extends TestCase
     {
         $this->signIn('super-admin');
     }
+
+    public function signInAsEmployee()
+    {
+        $this->signIn('employee');
+    }
 }

--- a/tests/Feature/HR/EmployeeTest.php
+++ b/tests/Feature/HR/EmployeeTest.php
@@ -4,12 +4,28 @@ namespace Tests\Feature\HR;
 
 use App\Models\HR\Employee;
 use App\User;
+use Illuminate\Auth\AuthenticationException;
 use Tests\Feature\FeatureTest;
 
 class EmployeeTest extends FeatureTest
 {
     /** @test */
-    public function user_name_gets_updated_when_employee_name_is_updated()
+    public function guest_cant_see_employee_list()
+    {
+        $this->withoutExceptionHandling()->expectException(AuthenticationException::class);
+        $this->get(route('employees'));
+    }
+
+    /** @test */
+    public function superadmin_can_see_employee_list()
+    {
+        $this->signInAsSuperAdmin();
+        $this->get(route('employees'))
+            ->assertStatus(200);
+    }
+
+    /** @test */
+    public function user_name_is_synced_with_employee_name()
     {
         $user = create(User::class);
         $employee = $user->employee;
@@ -17,20 +33,6 @@ class EmployeeTest extends FeatureTest
         $employee->update([
             'name' => $newName,
         ]);
-        $this->assertTrue($employee->user->name == $newName);
-    }
-
-    /** @test */
-    public function a_guest_cant_see_employee_list()
-    {
-        $this->get(route('employees'))->assertRedirect(route('login'));
-    }
-
-    /** @test */
-    public function an_authorized_user_can_see_employee_list()
-    {
-        $this->signInAsSuperAdmin();
-        $this->get(route('employees'))
-            ->assertStatus(200);
+        $this->assertEquals($employee->user->name, $newName);
     }
 }

--- a/tests/Feature/HR/EmployeeTest.php
+++ b/tests/Feature/HR/EmployeeTest.php
@@ -29,7 +29,7 @@ class EmployeeTest extends FeatureTest
     /** @test */
     public function an_authorized_user_can_see_employee_list()
     {
-        $this->anAuthorizedUser();
+        $this->signInAsSuperAdmin();
         $this->get(route('employees'))
             ->assertStatus(200);
     }

--- a/tests/Feature/KnowledgeCafe/Library/BookTest.php
+++ b/tests/Feature/KnowledgeCafe/Library/BookTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests\Feature\KnowledgeCafe\Library;
 
-use Tests\Feature\FeatureTest;
 use App\Models\KnowledgeCafe\Library\Book;
-use Illuminate\Auth\Access\AuthorizationException;
 use App\Models\KnowledgeCafe\Library\BookCategory;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
 use Symfony\Component\HttpFoundation\Response;
+use Tests\Feature\FeatureTest;
 
 class BookTest extends FeatureTest
 {
@@ -25,10 +26,9 @@ class BookTest extends FeatureTest
     }
 
     /** @test */
-    public function an_unauthorized_user_cant_see_books()
+    public function a_guest_cant_see_books()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->signIn();
+        $this->expectException(AuthenticationException::class);
         $this->get(route('books.index'));
     }
 
@@ -83,7 +83,7 @@ class BookTest extends FeatureTest
     }
 
     /** @test */
-    public function an_user_can_add_the_book_to_wishlist()
+    public function a_user_can_add_the_book_to_wishlist()
     {
         $this->signIn();
         $book = create(Book::class);
@@ -92,7 +92,7 @@ class BookTest extends FeatureTest
     }
 
     /** @test */
-    public function an_user_can_mark_book_as_read()
+    public function a_user_can_mark_book_as_read()
     {
         $this->signIn();
         $book = create(Book::class);

--- a/tests/Feature/KnowledgeCafe/Library/BookTest.php
+++ b/tests/Feature/KnowledgeCafe/Library/BookTest.php
@@ -18,9 +18,9 @@ class BookTest extends FeatureTest
     }
 
     /** @test */
-    public function an_authorized_user_can_see_books()
+    public function a_user_can_see_books()
     {
-        $this->signInAsSuperAdmin();
+        $this->signIn();
         $this->get(route('books.index'))
             ->assertStatus(Response::HTTP_OK);
     }

--- a/tests/Feature/KnowledgeCafe/Library/BookTest.php
+++ b/tests/Feature/KnowledgeCafe/Library/BookTest.php
@@ -18,9 +18,9 @@ class BookTest extends FeatureTest
     }
 
     /** @test */
-    public function a_user_can_see_books()
+    public function an_authorized_user_can_see_books()
     {
-        $this->signIn();
+        $this->signInAsEmployee();
         $this->get(route('books.index'))
             ->assertStatus(Response::HTTP_OK);
     }

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\Feature;
 
-class ProjectsTest extends FeatureTest
+class ProjectTest extends FeatureTest
 {
     /** @test */
     public function an_authorised_user_can_see_projects()
     {
-        $this->anAuthorizedUser();
+        $this->signInAsSuperAdmin();
         $this->get(route('projects'))
             ->assertStatus(200);
     }
@@ -31,7 +31,7 @@ class ProjectsTest extends FeatureTest
     /** @test */
     public function an_authorised_user_can_create_a_project()
     {
-        $this->anAuthorizedUser();
+        $this->signInAsSuperAdmin();
         $project = make('App\Models\Project');
         $response = $this->post(route('projects.store'), $project->toArray());
         $this->get($response->headers->get('Location'))
@@ -41,7 +41,7 @@ class ProjectsTest extends FeatureTest
     /** @test */
     public function an_authorised_user_can_update_a_project()
     {
-        $this->anAuthorizedUser();
+        $this->signInAsSuperAdmin();
         $project = create('App\Models\Project');
         $this->get(route('projects.edit', $project->id))
             ->assertSee($project->name);

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -5,7 +5,7 @@ namespace Tests\Feature;
 class ProjectTest extends FeatureTest
 {
     /** @test */
-    public function an_authorised_user_can_see_projects()
+    public function an_authorized_user_can_see_projects()
     {
         $this->signInAsSuperAdmin();
         $this->get(route('projects'))
@@ -13,7 +13,7 @@ class ProjectTest extends FeatureTest
     }
 
     /** @test */
-    public function an_unauthorised_user_cant_see_projects()
+    public function an_unauthorized_user_cant_see_projects()
     {
         $this->withoutExceptionHandling()
             ->expectException('Illuminate\Auth\Access\AuthorizationException');
@@ -29,7 +29,7 @@ class ProjectTest extends FeatureTest
     }
 
     /** @test */
-    public function an_authorised_user_can_create_a_project()
+    public function an_authorized_user_can_create_a_project()
     {
         $this->signInAsSuperAdmin();
         $project = make('App\Models\Project');
@@ -39,7 +39,7 @@ class ProjectTest extends FeatureTest
     }
 
     /** @test */
-    public function an_authorised_user_can_update_a_project()
+    public function an_authorized_user_can_update_a_project()
     {
         $this->signInAsSuperAdmin();
         $project = create('App\Models\Project');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,10 +9,10 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
-    protected function signIn($role = 'employee')
+    protected function signIn($role = null)
     {
         $user = create(User::class);
-        $user->assignRole($role);
+        is_null($role) ?: $user->assignRole($role);
         $this->be($user);
         return $this;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,15 +2,17 @@
 
 namespace Tests;
 
+use App\User;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
-    protected function signIn($user = null)
+    protected function signIn($role = 'employee')
     {
-        $user = $user ?: create('App\User');
+        $user = create(User::class);
+        $user->assignRole($role);
         $this->be($user);
         return $this;
     }

--- a/tests/Unit/KnowledgeCafe/Library/BookTest.php
+++ b/tests/Unit/KnowledgeCafe/Library/BookTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\KnowledgeCafe\Library;
 
-use Tests\TestCase;
 use App\Models\KnowledgeCafe\Library\Book;
+use Tests\TestCase;
 
 class BookTest extends TestCase
 {
@@ -31,21 +31,5 @@ class BookTest extends TestCase
     public function it_has_wishers()
     {
         $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $this->book->wishers);
-    }
-
-    /** @test */
-    public function it_can_mark_book_as_read_for_authenticated_user()
-    {
-        $this->signIn();
-        $this->book->markAsRead();
-        $this->assertTrue($this->book->readers->contains(auth()->user()));
-    }
-
-    /** @test */
-    public function it_can_add_to_users_wishlist()
-    {
-        $this->signIn();
-        $this->book->addToWishlist();
-        $this->assertTrue($this->book->wishers->contains(auth()->user()));
     }
 }


### PR DESCRIPTION
#566 

Changes include:

1. Remove `anAuthorizedUser` as it was confusing.
2. Updated `signIn` method. By default, it'll log in as an employee. 
3. Some cleanups in test files.