### PR TITLE
(#609) removed extra line in alert status

### DIFF
--- a/resources/views/status.blade.php
+++ b/resources/views/status.blade.php
@@ -13,6 +13,5 @@
 		<p>{!! session('status') !!}</p>
 		<span class="status-close"><b>&times;</b></span>
 	</div>
-	<br>
 @endif
 

--- a/resources/views/status.blade.php
+++ b/resources/views/status.blade.php
@@ -12,6 +12,6 @@
 	<div class="alert alert-success" role="alert">
 		<p>{!! session('status') !!}</p>
 		<span class="status-close"><b>&times;</b></span>
+		<br>
 	</div>
 @endif
-


### PR DESCRIPTION
#609

Removed the extra line that comes after we click on closing the status alert.